### PR TITLE
feat: 实现招募周期管理功能并完善相关业务逻辑

### DIFF
--- a/src/main/java/club/boyuan/official/controller/RecruitmentCycleController.java
+++ b/src/main/java/club/boyuan/official/controller/RecruitmentCycleController.java
@@ -1,0 +1,272 @@
+package club.boyuan.official.controller;
+
+import club.boyuan.official.dto.ResponseMessage;
+import club.boyuan.official.entity.RecruitmentCycle;
+import club.boyuan.official.entity.User;
+import club.boyuan.official.exception.BusinessException;
+import club.boyuan.official.exception.BusinessExceptionEnum;
+import club.boyuan.official.service.IRecruitmentCycleService;
+import club.boyuan.official.service.IUserService;
+import club.boyuan.official.utils.JwtTokenUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.AllArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * 招募周期Controller
+ */
+@RestController
+@RequestMapping("/api/cycles")
+@AllArgsConstructor
+public class RecruitmentCycleController {
+    
+    private static final Logger logger = LoggerFactory.getLogger(RecruitmentCycleController.class);
+    
+    private final IRecruitmentCycleService recruitmentCycleService;
+    private final IUserService userService;
+    private final JwtTokenUtil jwtTokenUtil;
+    private final HttpServletRequest request;
+    
+    /**
+     * 创建招募周期（仅管理员）
+     */
+    @PostMapping
+    public ResponseEntity<ResponseMessage<RecruitmentCycle>> createRecruitmentCycle(@RequestBody RecruitmentCycle recruitmentCycle) {
+        try {
+            // 验证管理员权限
+            User currentUser = getCurrentUser();
+            checkAdminPermission(currentUser);
+            
+            logger.info("管理员{}创建招募周期", currentUser.getUsername());
+            RecruitmentCycle createdCycle = recruitmentCycleService.createRecruitmentCycle(recruitmentCycle);
+            return ResponseEntity.ok(new ResponseMessage<>(200, "招募周期创建成功", createdCycle));
+        } catch (BusinessException e) {
+            logger.warn("创建招募周期业务异常，错误码: {}，错误信息: {}", e.getCode(), e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new ResponseMessage<>(e.getCode(), e.getMessage(), null));
+        } catch (Exception e) {
+            logger.error("创建招募周期系统异常", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ResponseMessage<>(BusinessExceptionEnum.SYSTEM_ERROR.getCode(), 
+                            "招募周期创建失败: " + e.getMessage(), null));
+        }
+    }
+    
+    /**
+     * 更新招募周期（仅管理员）
+     */
+    @PutMapping
+    public ResponseEntity<ResponseMessage<RecruitmentCycle>> updateRecruitmentCycle(@RequestBody RecruitmentCycle recruitmentCycle) {
+        try {
+            // 验证管理员权限
+            User currentUser = getCurrentUser();
+            checkAdminPermission(currentUser);
+            
+            logger.info("管理员{}更新招募周期，ID: {}", currentUser.getUsername(), recruitmentCycle.getCycleId());
+            RecruitmentCycle updatedCycle = recruitmentCycleService.updateRecruitmentCycle(recruitmentCycle);
+            return ResponseEntity.ok(new ResponseMessage<>(200, "招募周期更新成功", updatedCycle));
+        } catch (BusinessException e) {
+            logger.warn("更新招募周期业务异常，错误码: {}，错误信息: {}", e.getCode(), e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new ResponseMessage<>(e.getCode(), e.getMessage(), null));
+        } catch (Exception e) {
+            logger.error("更新招募周期系统异常", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ResponseMessage<>(BusinessExceptionEnum.SYSTEM_ERROR.getCode(), 
+                            "招募周期更新失败: " + e.getMessage(), null));
+        }
+    }
+    
+    /**
+     * 删除招募周期（仅管理员）
+     */
+    @DeleteMapping("/{cycleId}")
+    public ResponseEntity<ResponseMessage<String>> deleteRecruitmentCycle(@PathVariable Integer cycleId) {
+        try {
+            // 验证管理员权限
+            User currentUser = getCurrentUser();
+            checkAdminPermission(currentUser);
+            
+            logger.info("管理员{}删除招募周期，ID: {}", currentUser.getUsername(), cycleId);
+            recruitmentCycleService.deleteRecruitmentCycle(cycleId);
+            return ResponseEntity.ok(new ResponseMessage<>(200, "招募周期删除成功", "招募周期删除成功"));
+        } catch (BusinessException e) {
+            logger.warn("删除招募周期业务异常，错误码: {}，错误信息: {}", e.getCode(), e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new ResponseMessage<>(e.getCode(), e.getMessage(), null));
+        } catch (Exception e) {
+            logger.error("删除招募周期系统异常", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ResponseMessage<>(BusinessExceptionEnum.SYSTEM_ERROR.getCode(), 
+                            "招募周期删除失败: " + e.getMessage(), null));
+        }
+    }
+    
+    /**
+     * 根据ID获取招募周期
+     */
+    @GetMapping("/{cycleId}")
+    public ResponseEntity<ResponseMessage<RecruitmentCycle>> getRecruitmentCycleById(@PathVariable Integer cycleId) {
+        try {
+            logger.debug("获取招募周期，ID: {}", cycleId);
+            RecruitmentCycle cycle = recruitmentCycleService.getRecruitmentCycleById(cycleId);
+            if (cycle == null) {
+                logger.warn("招募周期不存在，ID: {}", cycleId);
+                throw new BusinessException(BusinessExceptionEnum.RECRUITMENT_CYCLE_NOT_FOUND);
+            }
+            return ResponseEntity.ok(new ResponseMessage<>(200, "获取招募周期成功", cycle));
+        } catch (BusinessException e) {
+            logger.warn("获取招募周期业务异常，错误码: {}，错误信息: {}", e.getCode(), e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new ResponseMessage<>(e.getCode(), e.getMessage(), null));
+        } catch (Exception e) {
+            logger.error("获取招募周期系统异常", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ResponseMessage<>(BusinessExceptionEnum.SYSTEM_ERROR.getCode(), 
+                            "获取招募周期失败: " + e.getMessage(), null));
+        }
+    }
+    
+    /**
+     * 获取所有招募周期
+     */
+    @GetMapping
+    public ResponseEntity<ResponseMessage<List<RecruitmentCycle>>> getAllRecruitmentCycles() {
+        try {
+            logger.debug("获取所有招募周期");
+            List<RecruitmentCycle> cycles = recruitmentCycleService.getAllRecruitmentCycles();
+            return ResponseEntity.ok(new ResponseMessage<>(200, "获取招募周期列表成功", cycles));
+        } catch (BusinessException e) {
+            logger.warn("获取招募周期列表业务异常，错误码: {}，错误信息: {}", e.getCode(), e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new ResponseMessage<>(e.getCode(), e.getMessage(), null));
+        } catch (Exception e) {
+            logger.error("获取招募周期列表系统异常", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ResponseMessage<>(BusinessExceptionEnum.SYSTEM_ERROR.getCode(), 
+                            "获取招募周期列表失败: " + e.getMessage(), null));
+        }
+    }
+    
+    /**
+     * 根据状态获取招募周期
+     */
+    @GetMapping("/status/{status}")
+    public ResponseEntity<ResponseMessage<List<RecruitmentCycle>>> getRecruitmentCyclesByStatus(@PathVariable Integer status) {
+        try {
+            logger.debug("根据状态获取招募周期，状态: {}", status);
+            List<RecruitmentCycle> cycles = recruitmentCycleService.getRecruitmentCyclesByStatus(status);
+            return ResponseEntity.ok(new ResponseMessage<>(200, "获取招募周期列表成功", cycles));
+        } catch (BusinessException e) {
+            logger.warn("根据状态获取招募周期列表业务异常，错误码: {}，错误信息: {}", e.getCode(), e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new ResponseMessage<>(e.getCode(), e.getMessage(), null));
+        } catch (Exception e) {
+            logger.error("根据状态获取招募周期列表系统异常", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ResponseMessage<>(BusinessExceptionEnum.SYSTEM_ERROR.getCode(), 
+                            "获取招募周期列表失败: " + e.getMessage(), null));
+        }
+    }
+    
+    /**
+     * 根据是否启用获取招募周期
+     */
+    @GetMapping("/active/{isActive}")
+    public ResponseEntity<ResponseMessage<List<RecruitmentCycle>>> getRecruitmentCyclesByIsActive(@PathVariable Integer isActive) {
+        try {
+            logger.debug("根据是否启用获取招募周期，是否启用: {}", isActive);
+            List<RecruitmentCycle> cycles = recruitmentCycleService.getRecruitmentCyclesByIsActive(isActive);
+            return ResponseEntity.ok(new ResponseMessage<>(200, "获取招募周期列表成功", cycles));
+        } catch (BusinessException e) {
+            logger.warn("根据是否启用获取招募周期列表业务异常，错误码: {}，错误信息: {}", e.getCode(), e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new ResponseMessage<>(e.getCode(), e.getMessage(), null));
+        } catch (Exception e) {
+            logger.error("根据是否启用获取招募周期列表系统异常", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ResponseMessage<>(BusinessExceptionEnum.SYSTEM_ERROR.getCode(), 
+                            "获取招募周期列表失败: " + e.getMessage(), null));
+        }
+    }
+    
+    /**
+     * 根据学年获取招募周期
+     */
+    @GetMapping("/academic-year/{academicYear}")
+    public ResponseEntity<ResponseMessage<RecruitmentCycle>> getRecruitmentCycleByAcademicYear(@PathVariable String academicYear) {
+        try {
+            logger.debug("根据学年获取招募周期，学年: {}", academicYear);
+            RecruitmentCycle cycle = recruitmentCycleService.getRecruitmentCycleByAcademicYear(academicYear);
+            if (cycle == null) {
+                logger.warn("招募周期不存在，学年: {}", academicYear);
+                throw new BusinessException(BusinessExceptionEnum.RECRUITMENT_CYCLE_NOT_FOUND);
+            }
+            return ResponseEntity.ok(new ResponseMessage<>(200, "获取招募周期成功", cycle));
+        } catch (BusinessException e) {
+            logger.warn("根据学年获取招募周期业务异常，错误码: {}，错误信息: {}", e.getCode(), e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new ResponseMessage<>(e.getCode(), e.getMessage(), null));
+        } catch (Exception e) {
+            logger.error("根据学年获取招募周期系统异常", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ResponseMessage<>(BusinessExceptionEnum.SYSTEM_ERROR.getCode(), 
+                            "获取招募周期失败: " + e.getMessage(), null));
+        }
+    }
+    
+    /**
+     * 从请求头获取JWT令牌
+     */
+    private String getTokenFromHeader() {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+    
+    /**
+     * 验证JWT令牌并获取用户信息
+     */
+    private User getCurrentUser() {
+        String token = getTokenFromHeader();
+        if (token == null) {
+            throw new BusinessException(BusinessExceptionEnum.JWT_VERIFICATION_FAILED);
+        }
+        
+        try {
+            // 验证令牌并获取用户名
+            String username = jwtTokenUtil.extractUsername(token);
+            if (!jwtTokenUtil.validateToken(token, username)) {
+                throw new BusinessException(BusinessExceptionEnum.JWT_VERIFICATION_FAILED);
+            }
+            
+            // 获取用户信息
+            User user = userService.getUserByUsername(username);
+            if (user == null) {
+                throw new BusinessException(BusinessExceptionEnum.JWT_VERIFICATION_FAILED);
+            }
+            
+            return user;
+        } catch (Exception e) {
+            throw new BusinessException(BusinessExceptionEnum.JWT_VERIFICATION_FAILED);
+        }
+    }
+    
+    /**
+     * 验证管理员权限
+     */
+    private void checkAdminPermission(User user) {
+        if (!User.ROLE_ADMIN.equals(user.getRole())) {
+            throw new BusinessException(BusinessExceptionEnum.USER_ROLE_NOT_AUTHORIZED);
+        }
+    }
+}

--- a/src/main/java/club/boyuan/official/controller/UserController.java
+++ b/src/main/java/club/boyuan/official/controller/UserController.java
@@ -294,6 +294,14 @@ public class UserController {
                 existingUser.setPhone((String) userInfo.get("phone"));
                 logger.debug("更新电话为: {}", userInfo.get("phone"));
             }
+            if (userInfo.containsKey("major") && userInfo.get("major") != null) {
+                existingUser.setMajor((String) userInfo.get("major"));
+                logger.debug("更新专业为: {}", userInfo.get("major"));
+            }
+            if (userInfo.containsKey("github") && userInfo.get("github") != null) {
+                existingUser.setGithub((String) userInfo.get("github"));
+                logger.debug("更新GitHub地址为: {}", userInfo.get("github"));
+            }
             if (userInfo.containsKey("dept") && userInfo.get("dept") != null) {
                 existingUser.setDept((String) userInfo.get("dept"));
                 logger.debug("更新部门为: {}", userInfo.get("dept"));
@@ -500,6 +508,14 @@ public class UserController {
             if (userInfo.containsKey("phone") && userInfo.get("phone") != null) {
                 existingUser.setPhone((String) userInfo.get("phone"));
                 logger.debug("更新电话为: {}", userInfo.get("phone"));
+            }
+            if (userInfo.containsKey("major") && userInfo.get("major") != null) {
+                existingUser.setMajor((String) userInfo.get("major"));
+                logger.debug("更新专业为: {}", userInfo.get("major"));
+            }
+            if (userInfo.containsKey("github") && userInfo.get("github") != null) {
+                existingUser.setGithub((String) userInfo.get("github"));
+                logger.debug("更新GitHub地址为: {}", userInfo.get("github"));
             }
             if (userInfo.containsKey("dept") && userInfo.get("dept") != null) {
                 existingUser.setDept((String) userInfo.get("dept"));

--- a/src/main/java/club/boyuan/official/dto/UserDTO.java
+++ b/src/main/java/club/boyuan/official/dto/UserDTO.java
@@ -23,6 +23,8 @@ public class UserDTO {
     private String name;
     @NotBlank(message = "电话不能为空")
     private String phone;
+    private String major;
+    private String github;
     @Pattern(regexp = "ADMIN|USER", message = "角色必须是ADMIN或USER")
     private String role;
     private boolean status;
@@ -41,6 +43,6 @@ public class UserDTO {
     }
 
     public String toString() {
-        return "UserDTO{userId = " + userId + ", username = " + username + ", password = " + password + ", email = " + email + ", name = " + name + ", phone = " + phone + ", role = " + role + ", status = " + status + ", dept = " + dept + ", avatar = " + avatar + "}";
+        return "UserDTO{userId = " + userId + ", username = " + username + ", password = " + password + ", email = " + email + ", name = " + name + ", phone = " + phone + ", major = " + major + ", github = " + github + ", role = " + role + ", status = " + status + ", dept = " + dept + ", avatar = " + avatar + "}";
     }
 }

--- a/src/main/java/club/boyuan/official/entity/RecruitmentCycle.java
+++ b/src/main/java/club/boyuan/official/entity/RecruitmentCycle.java
@@ -1,0 +1,155 @@
+package club.boyuan.official.entity;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 招募周期实体类
+ * 用于管理社团的招募活动周期
+ */
+@Entity
+@Table(name = "recruitment_cycle")
+public class RecruitmentCycle {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "cycle_id")
+    private Integer cycleId;
+
+    @Column(name = "cycle_name", nullable = false)
+    private String cycleName;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "start_date", nullable = false)
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate endDate;
+
+    @Column(name = "academic_year", nullable = false)
+    private String academicYear;
+
+    /**
+     * 招募活动状态:
+     * 1 - 未开始
+     * 2 - 进行中
+     * 3 - 已结束
+     * 4 - 已关闭
+     */
+    @Column(name = "status", nullable = false, columnDefinition = "TINYINT DEFAULT 1")
+    private Integer status;
+
+    /**
+     * 是否启用:
+     * 0 - 禁用
+     * 1 - 启用
+     */
+    @Column(name = "is_active", nullable = false, columnDefinition = "TINYINT(1) DEFAULT 1")
+    private Integer isActive;
+
+    @Column(name = "created_at", columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime updatedAt;
+
+    // 构造函数
+    public RecruitmentCycle() {
+    }
+
+    public RecruitmentCycle(String cycleName, String description, LocalDate startDate, LocalDate endDate, String academicYear) {
+        this.cycleName = cycleName;
+        this.description = description;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.academicYear = academicYear;
+    }
+
+    // Getter 和 Setter 方法
+    public Integer getCycleId() {
+        return cycleId;
+    }
+
+    public void setCycleId(Integer cycleId) {
+        this.cycleId = cycleId;
+    }
+
+    public String getCycleName() {
+        return cycleName;
+    }
+
+    public void setCycleName(String cycleName) {
+        this.cycleName = cycleName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    public String getAcademicYear() {
+        return academicYear;
+    }
+
+    public void setAcademicYear(String academicYear) {
+        this.academicYear = academicYear;
+    }
+
+    public Integer getStatus() {
+        return status;
+    }
+
+    public void setStatus(Integer status) {
+        this.status = status;
+    }
+
+    public Integer getIsActive() {
+        return isActive;
+    }
+
+    public void setIsActive(Integer isActive) {
+        this.isActive = isActive;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/club/boyuan/official/entity/Resume.java
+++ b/src/main/java/club/boyuan/official/entity/Resume.java
@@ -1,8 +1,8 @@
 package club.boyuan.official.entity;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
-import com.fasterxml.jackson.annotation.JsonFormat;
 
 @Entity
 @Table(name = "resume")
@@ -18,7 +18,14 @@ public class Resume {
     @Column(name = "cycle_id", nullable = false)
     private Integer cycleId;
 
-    // 修复字段定义，使其与数据库结构匹配
+    /**
+     * 简历状态:
+     * 1 - 草稿
+     * 2 - 已提交
+     * 3 - 评审中
+     * 4 - 通过
+     * 5 - 未通过
+     */
     @Column(name = "status", columnDefinition = "tinyint")
     private Integer status;
 

--- a/src/main/java/club/boyuan/official/entity/ResumeFieldDefinition.java
+++ b/src/main/java/club/boyuan/official/entity/ResumeFieldDefinition.java
@@ -1,8 +1,8 @@
 package club.boyuan.official.entity;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
-import com.fasterxml.jackson.annotation.JsonFormat;
 
 @Entity
 @Table(name = "resume_field_definition")

--- a/src/main/java/club/boyuan/official/entity/ResumeFieldValue.java
+++ b/src/main/java/club/boyuan/official/entity/ResumeFieldValue.java
@@ -1,8 +1,8 @@
 package club.boyuan.official.entity;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
-import com.fasterxml.jackson.annotation.JsonFormat;
 
 @Entity
 @Table(name = "resume_field_value")

--- a/src/main/java/club/boyuan/official/entity/User.java
+++ b/src/main/java/club/boyuan/official/entity/User.java
@@ -35,6 +35,12 @@ public class User {
     @Column(name = "phone")
     private String phone;
 
+    @Column(name = "major")
+    private String major;
+
+    @Column(name = "github")
+    private String github;
+
     @Column(name = "dept")
     private String dept;
 
@@ -118,6 +124,22 @@ public class User {
         this.phone = phone;
     }
 
+    public String getMajor() {
+        return major;
+    }
+
+    public void setMajor(String major) {
+        this.major = major;
+    }
+
+    public String getGithub() {
+        return github;
+    }
+
+    public void setGithub(String github) {
+        this.github = github;
+    }
+
     public String getDept() {
         return dept;
     }
@@ -159,6 +181,6 @@ public class User {
     }
 
     public String toString() {
-        return "User{ROLE_ADMIN = " + ROLE_ADMIN + ", ROLE_USER = " + ROLE_USER + ", userId = " + userId + ", username = " + username + ", password = " + password + ", role = " + role + ", name = " + name + ", email = " + email + ", phone = " + phone + ", dept = " + dept + ", createTime = " + createTime + ", status = " + status + ", isMember = " + isMember + "}";
+        return "User{ROLE_ADMIN = " + ROLE_ADMIN + ", ROLE_USER = " + ROLE_USER + ", userId = " + userId + ", username = " + username + ", password = " + password + ", role = " + role + ", name = " + name + ", email = " + email + ", phone = " + phone + ", major = " + major + ", github = " + github + ", dept = " + dept + ", createTime = " + createTime + ", status = " + status + ", isMember = " + isMember + "}";
     }
 }

--- a/src/main/java/club/boyuan/official/exception/BusinessExceptionEnum.java
+++ b/src/main/java/club/boyuan/official/exception/BusinessExceptionEnum.java
@@ -66,6 +66,13 @@ public enum BusinessExceptionEnum {
     RESUME_FIELD_DEFINITION_DELETE_FAILED(3103, "简历字段定义删除失败"),
     RESUME_FIELD_DEFINITION_QUERY_FAILED(3104, "简历字段定义查询失败"),
     
+    // 招募周期相关异常 (3200-3299)
+    RECRUITMENT_CYCLE_NOT_FOUND(3201, "招募周期不存在"),
+    RECRUITMENT_CYCLE_CREATE_FAILED(3202, "招募周期创建失败"),
+    RECRUITMENT_CYCLE_UPDATE_FAILED(3203, "招募周期更新失败"),
+    RECRUITMENT_CYCLE_DELETE_FAILED(3204, "招募周期删除失败"),
+    RECRUITMENT_CYCLE_QUERY_FAILED(3205, "招募周期查询失败"),
+    
     // 数据库相关异常 (4000-4099)
     DATABASE_OPERATION_FAILED(4001, "数据库操作失败"),
     DATABASE_CONNECTION_FAILED(4002, "数据库连接失败"),

--- a/src/main/java/club/boyuan/official/mapper/RecruitmentCycleMapper.java
+++ b/src/main/java/club/boyuan/official/mapper/RecruitmentCycleMapper.java
@@ -1,0 +1,69 @@
+package club.boyuan.official.mapper;
+
+import club.boyuan.official.entity.RecruitmentCycle;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+/**
+ * 招募周期Mapper接口
+ */
+@Mapper
+public interface RecruitmentCycleMapper {
+    
+    /**
+     * 插入招募周期
+     * @param recruitmentCycle 招募周期实体
+     * @return 影响行数
+     */
+    int insert(RecruitmentCycle recruitmentCycle);
+    
+    /**
+     * 根据ID更新招募周期
+     * @param recruitmentCycle 招募周期实体
+     * @return 影响行数
+     */
+    int update(RecruitmentCycle recruitmentCycle);
+    
+    /**
+     * 根据ID删除招募周期
+     * @param cycleId 招募周期ID
+     * @return 影响行数
+     */
+    int deleteById(Integer cycleId);
+    
+    /**
+     * 根据ID查询招募周期
+     * @param cycleId 招募周期ID
+     * @return 招募周期实体
+     */
+    RecruitmentCycle findById(Integer cycleId);
+    
+    /**
+     * 查询所有招募周期
+     * @return 招募周期列表
+     */
+    List<RecruitmentCycle> findAll();
+    
+    /**
+     * 根据状态查询招募周期
+     * @param status 状态
+     * @return 招募周期列表
+     */
+    List<RecruitmentCycle> findByStatus(Integer status);
+    
+    /**
+     * 根据是否启用查询招募周期
+     * @param isActive 是否启用
+     * @return 招募周期列表
+     */
+    List<RecruitmentCycle> findByIsActive(Integer isActive);
+    
+    /**
+     * 根据学年查询招募周期
+     * @param academicYear 学年
+     * @return 招募周期实体
+     */
+    RecruitmentCycle findByAcademicYear(String academicYear);
+}

--- a/src/main/java/club/boyuan/official/service/IRecruitmentCycleService.java
+++ b/src/main/java/club/boyuan/official/service/IRecruitmentCycleService.java
@@ -1,0 +1,65 @@
+package club.boyuan.official.service;
+
+import club.boyuan.official.entity.RecruitmentCycle;
+
+import java.util.List;
+
+/**
+ * 招募周期服务接口
+ */
+public interface IRecruitmentCycleService {
+    
+    /**
+     * 创建招募周期
+     * @param recruitmentCycle 招募周期实体
+     * @return 创建后的招募周期
+     */
+    RecruitmentCycle createRecruitmentCycle(RecruitmentCycle recruitmentCycle);
+    
+    /**
+     * 更新招募周期
+     * @param recruitmentCycle 招募周期实体
+     * @return 更新后的招募周期
+     */
+    RecruitmentCycle updateRecruitmentCycle(RecruitmentCycle recruitmentCycle);
+    
+    /**
+     * 删除招募周期
+     * @param cycleId 招募周期ID
+     */
+    void deleteRecruitmentCycle(Integer cycleId);
+    
+    /**
+     * 根据ID获取招募周期
+     * @param cycleId 招募周期ID
+     * @return 招募周期实体
+     */
+    RecruitmentCycle getRecruitmentCycleById(Integer cycleId);
+    
+    /**
+     * 获取所有招募周期
+     * @return 招募周期列表
+     */
+    List<RecruitmentCycle> getAllRecruitmentCycles();
+    
+    /**
+     * 根据状态获取招募周期
+     * @param status 状态
+     * @return 招募周期列表
+     */
+    List<RecruitmentCycle> getRecruitmentCyclesByStatus(Integer status);
+    
+    /**
+     * 根据是否启用获取招募周期
+     * @param isActive 是否启用
+     * @return 招募周期列表
+     */
+    List<RecruitmentCycle> getRecruitmentCyclesByIsActive(Integer isActive);
+    
+    /**
+     * 根据学年获取招募周期
+     * @param academicYear 学年
+     * @return 招募周期实体
+     */
+    RecruitmentCycle getRecruitmentCycleByAcademicYear(String academicYear);
+}

--- a/src/main/java/club/boyuan/official/service/impl/RecruitmentCycleServiceImpl.java
+++ b/src/main/java/club/boyuan/official/service/impl/RecruitmentCycleServiceImpl.java
@@ -1,0 +1,137 @@
+package club.boyuan.official.service.impl;
+
+import club.boyuan.official.entity.RecruitmentCycle;
+import club.boyuan.official.mapper.RecruitmentCycleMapper;
+import club.boyuan.official.service.IRecruitmentCycleService;
+import lombok.AllArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * 招募周期服务实现类
+ */
+@Service
+@AllArgsConstructor
+public class RecruitmentCycleServiceImpl implements IRecruitmentCycleService {
+    
+    private static final Logger logger = LoggerFactory.getLogger(RecruitmentCycleServiceImpl.class);
+    
+    private final RecruitmentCycleMapper recruitmentCycleMapper;
+    
+    @Override
+    public RecruitmentCycle createRecruitmentCycle(RecruitmentCycle recruitmentCycle) {
+        logger.info("创建招募周期，名称: {}", recruitmentCycle.getCycleName());
+        try {
+            // 设置默认值
+            if (recruitmentCycle.getStatus() == null) {
+                recruitmentCycle.setStatus(1); // 默认未开始
+            }
+            if (recruitmentCycle.getIsActive() == null) {
+                recruitmentCycle.setIsActive(1); // 默认启用
+            }
+            
+            recruitmentCycleMapper.insert(recruitmentCycle);
+            logger.info("招募周期创建成功，ID: {}", recruitmentCycle.getCycleId());
+            return recruitmentCycle;
+        } catch (Exception e) {
+            logger.error("创建招募周期失败，名称: {}", recruitmentCycle.getCycleName(), e);
+            throw e;
+        }
+    }
+    
+    @Override
+    public RecruitmentCycle updateRecruitmentCycle(RecruitmentCycle recruitmentCycle) {
+        logger.info("更新招募周期，ID: {}", recruitmentCycle.getCycleId());
+        try {
+            RecruitmentCycle existingCycle = recruitmentCycleMapper.findById(recruitmentCycle.getCycleId());
+            if (existingCycle == null) {
+                logger.warn("尝试更新不存在的招募周期，ID: {}", recruitmentCycle.getCycleId());
+                throw new IllegalArgumentException("招募周期不存在");
+            }
+            
+            recruitmentCycleMapper.update(recruitmentCycle);
+            logger.info("招募周期更新成功，ID: {}", recruitmentCycle.getCycleId());
+            return recruitmentCycle;
+        } catch (Exception e) {
+            logger.error("更新招募周期失败，ID: {}", recruitmentCycle.getCycleId(), e);
+            throw e;
+        }
+    }
+    
+    @Override
+    public void deleteRecruitmentCycle(Integer cycleId) {
+        logger.info("删除招募周期，ID: {}", cycleId);
+        try {
+            RecruitmentCycle existingCycle = recruitmentCycleMapper.findById(cycleId);
+            if (existingCycle == null) {
+                logger.warn("尝试删除不存在的招募周期，ID: {}", cycleId);
+                throw new IllegalArgumentException("招募周期不存在");
+            }
+            
+            recruitmentCycleMapper.deleteById(cycleId);
+            logger.info("招募周期删除成功，ID: {}", cycleId);
+        } catch (Exception e) {
+            logger.error("删除招募周期失败，ID: {}", cycleId, e);
+            throw e;
+        }
+    }
+    
+    @Override
+    public RecruitmentCycle getRecruitmentCycleById(Integer cycleId) {
+        logger.debug("根据ID获取招募周期，ID: {}", cycleId);
+        try {
+            return recruitmentCycleMapper.findById(cycleId);
+        } catch (Exception e) {
+            logger.error("根据ID获取招募周期失败，ID: {}", cycleId, e);
+            throw e;
+        }
+    }
+    
+    @Override
+    public List<RecruitmentCycle> getAllRecruitmentCycles() {
+        logger.debug("获取所有招募周期");
+        try {
+            return recruitmentCycleMapper.findAll();
+        } catch (Exception e) {
+            logger.error("获取所有招募周期失败", e);
+            throw e;
+        }
+    }
+    
+    @Override
+    public List<RecruitmentCycle> getRecruitmentCyclesByStatus(Integer status) {
+        logger.debug("根据状态获取招募周期，状态: {}", status);
+        try {
+            return recruitmentCycleMapper.findByStatus(status);
+        } catch (Exception e) {
+            logger.error("根据状态获取招募周期失败，状态: {}", status, e);
+            throw e;
+        }
+    }
+    
+    @Override
+    public List<RecruitmentCycle> getRecruitmentCyclesByIsActive(Integer isActive) {
+        logger.debug("根据是否启用获取招募周期，是否启用: {}", isActive);
+        try {
+            return recruitmentCycleMapper.findByIsActive(isActive);
+        } catch (Exception e) {
+            logger.error("根据是否启用获取招募周期失败，是否启用: {}", isActive, e);
+            throw e;
+        }
+    }
+    
+    @Override
+    public RecruitmentCycle getRecruitmentCycleByAcademicYear(String academicYear) {
+        logger.debug("根据学年获取招募周期，学年: {}", academicYear);
+        try {
+            return recruitmentCycleMapper.findByAcademicYear(academicYear);
+        } catch (Exception e) {
+            logger.error("根据学年获取招募周期失败，学年: {}", academicYear, e);
+            throw e;
+        }
+    }
+}

--- a/src/main/resources/db/official.sql
+++ b/src/main/resources/db/official.sql
@@ -11,205 +11,470 @@
  Target Server Version : 80041 (8.0.41)
  File Encoding         : 65001
 
- Date: 15/08/2025 17:32:19
+ Date: 24/08/2025 23:55:00
 */
 
 SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci;
 SET FOREIGN_KEY_CHECKS = 0;
 
 -- ----------------------------
+-- Table structure for recruitment_cycle
+-- ----------------------------
+DROP TABLE IF EXISTS `recruitment_cycle`;
+CREATE TABLE `recruitment_cycle`
+(
+    `cycle_id`      int                                                           NOT NULL AUTO_INCREMENT COMMENT '招募活动ID',
+    `cycle_name`    varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '招募活动名称',
+    `description`   text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci COMMENT '活动基本介绍',
+    `start_date`    date                                                          NOT NULL COMMENT '活动开始日期',
+    `end_date`      date                                                          NOT NULL COMMENT '活动截止日期',
+    `academic_year` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci  NOT NULL COMMENT '学年',
+    `status`        tinyint                                                       NOT NULL DEFAULT '1' COMMENT '活动状态：1(未开始), 2(进行中), 3(已结束), 4(已关闭)',
+    `is_active`     tinyint(1)                                                    NOT NULL DEFAULT '1' COMMENT '是否启用：0(禁用), 1(启用)',
+    `created_at`    timestamp                                                     NULL     DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    `updated_at`    timestamp                                                     NULL     DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    PRIMARY KEY (`cycle_id`) USING BTREE
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 1
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci
+  ROW_FORMAT = DYNAMIC COMMENT ='招募活动表';
+
+-- ----------------------------
+-- Records of recruitment_cycle
+-- ----------------------------
+INSERT INTO `recruitment_cycle`
+VALUES (1, '2024年秋季招新', '华东师范大学博远社团2024年秋季招新活动，欢迎各位同学加入我们的大家庭！', '2024-09-01',
+        '2024-09-30', '2024-2025学年', 3, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00'),
+       (2, '2025年秋季招新', '华东师范大学博远社团2025年秋季招新活动，寻找志同道合的你！', '2025-09-01', '2025-09-30',
+        '2025-2026学年', 2, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00');
+
+-- ----------------------------
 -- Table structure for award_experience
 -- ----------------------------
 DROP TABLE IF EXISTS `award_experience`;
-CREATE TABLE `award_experience`  (
-  `award_id` int NOT NULL AUTO_INCREMENT,
-  `user_id` int NOT NULL,
-  `award_name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `award_time` date NOT NULL,
-  `description` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL,
-  PRIMARY KEY (`award_id`) USING BTREE,
-  INDEX `user_id`(`user_id` ASC) USING BTREE,
-  CONSTRAINT `award_experience_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `user` (`user_id`) ON DELETE CASCADE ON UPDATE RESTRICT
-) ENGINE = InnoDB AUTO_INCREMENT = 7 CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci ROW_FORMAT = Dynamic;
+CREATE TABLE `award_experience`
+(
+    `award_id`    int                                                           NOT NULL AUTO_INCREMENT,
+    `user_id`     int                                                           NOT NULL,
+    `award_name`  varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+    `award_time`  date                                                          NOT NULL,
+    `description` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci         NULL,
+    `created_at`  timestamp                                                     NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at`  timestamp                                                     NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`award_id`) USING BTREE,
+    INDEX `user_id` (`user_id` ASC) USING BTREE,
+    CONSTRAINT `award_experience_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `user` (`user_id`) ON DELETE CASCADE ON UPDATE RESTRICT
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 4
+  CHARACTER SET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci
+  ROW_FORMAT = Dynamic;
 
 -- ----------------------------
 -- Records of award_experience
 -- ----------------------------
-INSERT INTO `award_experience` (`award_id`, `user_id`, `award_name`, `award_time`, `description`) VALUES (1, 2, 'ACM程序设计竞赛银奖', '2023-05-20', '在省级ACM程序设计竞赛中获得银奖');
-INSERT INTO `award_experience` (`award_id`, `user_id`, `award_name`, `award_time`, `description`) VALUES (2, 2, '校级优秀学生奖学金', '2023-12-01', '因学业成绩优异获得校级一等奖学金');
-INSERT INTO `award_experience` (`award_id`, `user_id`, `award_name`, `award_time`, `description`) VALUES (3, 2, '数学建模竞赛二等奖', '2023-09-15', '在全国大学生数学建模竞赛中获得二等奖');
-INSERT INTO `award_experience` (`award_id`, `user_id`, `award_name`, `award_time`, `description`) VALUES (4, 3, '大学生创新创业大赛一等奖', '2023-08-10', '带领团队在校级创新创业大赛中获得一等奖');
-INSERT INTO `award_experience` (`award_id`, `user_id`, `award_name`, `award_time`, `description`) VALUES (5, 3, '英语演讲比赛三等奖', '2023-11-25', '在外语学院举办的英语演讲比赛中获得三等奖');
-INSERT INTO `award_experience` (`award_id`, `user_id`, `award_name`, `award_time`, `description`) VALUES (6, 3, '优秀学生干部', '2023-12-01', '因担任学生会干部期间表现优秀获得此荣誉');
-
--- 添加更多测试用户的获奖经历
-INSERT INTO `award_experience` (`award_id`, `user_id`, `award_name`, `award_time`, `description`) VALUES (7, 4, '全国大学生数学竞赛一等奖', '2024-03-15', '在全国大学生数学竞赛中获得一等奖');
-INSERT INTO `award_experience` (`award_id`, `user_id`, `award_name`, `award_time`, `description`) VALUES (8, 4, '校级优秀学生干部', '2024-12-01', '担任学生会主席期间工作出色');
-INSERT INTO `award_experience` (`award_id`, `user_id`, `award_name`, `award_time`, `description`) VALUES (9, 5, 'ACM国际大学生程序设计竞赛区域赛银奖', '2024-05-20', '在ACM国际大学生程序设计竞赛区域赛中获得银奖');
-INSERT INTO `award_experience` (`award_id`, `user_id`, `award_name`, `award_time`, `description`) VALUES (10, 5, '蓝桥杯全国软件和信息技术专业人才大赛二等奖', '2024-04-10', '在蓝桥杯全国软件和信息技术专业人才大赛中获得二等奖');
-INSERT INTO `award_experience` (`award_id`, `user_id`, `award_name`, `award_time`, `description`) VALUES (11, 6, '全国大学生英语竞赛特等奖', '2024-05-15', '在全国大学生英语竞赛中获得特等奖');
-INSERT INTO `award_experience` (`award_id`, `user_id`, `award_name`, `award_time`, `description`) VALUES (12, 6, '校级社会实践优秀个人', '2024-12-01', '在暑期社会实践活动中表现突出');
-
--- ----------------------------
--- Table structure for resume
--- ----------------------------
-DROP TABLE IF EXISTS `resume`;
-CREATE TABLE `resume`  (
-  `resume_id` int NOT NULL AUTO_INCREMENT,
-  `user_id` int NOT NULL,
-  `cycle_id` int NOT NULL,
-  `status` tinyint NULL DEFAULT 1,
-  `submitted_at` timestamp NULL DEFAULT NULL,
-  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
-  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  PRIMARY KEY (`resume_id`) USING BTREE,
-  INDEX `user_id`(`user_id` ASC) USING BTREE,
-  CONSTRAINT `resume_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `user` (`user_id`) ON DELETE RESTRICT ON UPDATE RESTRICT
-) ENGINE = InnoDB AUTO_INCREMENT = 2 CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci ROW_FORMAT = Dynamic;
-
--- ----------------------------
--- Records of resume
--- ----------------------------
-INSERT INTO `resume` (`resume_id`, `user_id`, `cycle_id`, `status`, `submitted_at`, `created_at`, `updated_at`) VALUES (1, 2, 2024, 3, '2025-08-15 14:03:27', '2025-08-15 13:58:51', '2025-08-15 14:05:36');
-INSERT INTO `resume` (`resume_id`, `user_id`, `cycle_id`, `status`, `submitted_at`, `created_at`, `updated_at`) VALUES (2, 4, 2025, 2, '2025-08-15 15:30:00', '2025-08-15 15:25:10', '2025-08-15 15:30:00');
-INSERT INTO `resume` (`resume_id`, `user_id`, `cycle_id`, `status`, `submitted_at`, `created_at`, `updated_at`) VALUES (3, 5, 2025, 1, '2025-08-15 16:45:00', '2025-08-15 16:40:20', '2025-08-15 16:45:00');
-INSERT INTO `resume` (`resume_id`, `user_id`, `cycle_id`, `status`, `submitted_at`, `created_at`, `updated_at`) VALUES (4, 6, 2025, 3, '2025-08-15 17:15:00', '2025-08-15 17:10:30', '2025-08-15 17:20:00');
-
--- ----------------------------
--- Table structure for resume_field_definition
--- ----------------------------
-DROP TABLE IF EXISTS `resume_field_definition`;
-CREATE TABLE `resume_field_definition`  (
-  `field_id` int NOT NULL AUTO_INCREMENT,
-  `cycle_id` int NOT NULL,
-  `field_key` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `field_label` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `is_required` tinyint(1) NULL DEFAULT 0,
-  `sort_order` int NULL DEFAULT 0,
-  `is_active` tinyint(1) NULL DEFAULT 1,
-  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
-  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  PRIMARY KEY (`field_id`) USING BTREE
-) ENGINE = InnoDB AUTO_INCREMENT = 4 CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci ROW_FORMAT = Dynamic;
-
--- ----------------------------
--- Records of resume_field_definition
--- ----------------------------
-INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`, `is_active`, `created_at`, `updated_at`) VALUES (1, 2024, 'personal_statement', '个人陈述（必填）', 1, 1, 1, '2025-08-15 13:52:46', '2025-08-15 14:24:24');
-INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`, `is_active`, `created_at`, `updated_at`) VALUES (2, 2024, 'project_experience', '项目经历', 1, 2, 1, '2025-08-15 13:52:58', '2025-08-15 13:52:58');
-INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`, `is_active`, `created_at`, `updated_at`) VALUES (3, 2024, 'skills', '技能', 0, 3, 1, '2025-08-15 13:53:02', '2025-08-15 13:53:02');
-
--- 添加2025年份的简历字段定义
-INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`, `is_active`, `created_at`, `updated_at`) VALUES (4, 2025, 'name', '姓名', 1, 1, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00');
-INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`, `is_active`, `created_at`, `updated_at`) VALUES (5, 2025, 'major', '专业', 1, 2, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00');
-INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`, `is_active`, `created_at`, `updated_at`) VALUES (6, 2025, 'email', '邮箱', 1, 3, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00');
-INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`, `is_active`, `created_at`, `updated_at`) VALUES (7, 2025, 'phone', '手机号', 1, 4, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00');
-INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`, `is_active`, `created_at`, `updated_at`) VALUES (8, 2025, 'grade', '年级', 1, 5, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00');
-INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`, `is_active`, `created_at`, `updated_at`) VALUES (9, 2025, 'gender', '性别', 1, 6, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00');
-INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`, `is_active`, `created_at`, `updated_at`) VALUES (10, 2025, 'expected_department', '期望部门', 1, 7, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00');
-INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`, `is_active`, `created_at`, `updated_at`) VALUES (11, 2025, 'self_introduction', '自我介绍', 1, 8, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00');
-INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`, `is_active`, `created_at`, `updated_at`) VALUES (12, 2025, 'tech_stack', '技术栈', 1, 9, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00');
-INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`, `is_active`, `created_at`, `updated_at`) VALUES (13, 2025, 'project_experience', '项目经验', 1, 10, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00');
-INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`, `is_active`, `created_at`, `updated_at`) VALUES (14, 2025, 'expected_interview_time', '期望的面试时间', 0, 11, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00');
-INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`, `is_active`, `created_at`, `updated_at`) VALUES (15, 2025, 'personal_photo', '个人照片', 0, 12, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00');
-
--- ----------------------------
--- Table structure for resume_field_value
--- ----------------------------
-DROP TABLE IF EXISTS `resume_field_value`;
-CREATE TABLE `resume_field_value`  (
-  `value_id` int NOT NULL AUTO_INCREMENT,
-  `resume_id` int NOT NULL,
-  `field_id` int NOT NULL,
-  `field_value` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL,
-  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
-  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  PRIMARY KEY (`value_id`) USING BTREE,
-  INDEX `resume_id`(`resume_id` ASC) USING BTREE,
-  INDEX `field_id`(`field_id` ASC) USING BTREE,
-  CONSTRAINT `resume_field_value_ibfk_1` FOREIGN KEY (`resume_id`) REFERENCES `resume` (`resume_id`) ON DELETE CASCADE ON UPDATE RESTRICT,
-  CONSTRAINT `resume_field_value_ibfk_2` FOREIGN KEY (`field_id`) REFERENCES `resume_field_definition` (`field_id`) ON DELETE RESTRICT ON UPDATE RESTRICT
-) ENGINE = InnoDB AUTO_INCREMENT = 4 CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci ROW_FORMAT = Dynamic;
-
--- ----------------------------
--- Records of resume_field_value
--- ----------------------------
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (1, 1, 1, '我是一个热爱技术的学生，希望能在技术部门发挥自己的才能。', '2025-08-15 14:00:04', '2025-08-15 14:00:04');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (2, 1, 2, '参与开发了学校图书馆管理系统，使用Java和MySQL。', '2025-08-15 14:00:04', '2025-08-15 14:00:04');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (3, 1, 3, '熟悉Java、Python和前端技术。', '2025-08-15 14:00:04', '2025-08-15 14:00:04');
-
--- 添加2025年份的简历字段值
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (4, 2, 4, '测试用户1', '2025-08-15 15:25:10', '2025-08-15 15:25:10');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (5, 2, 5, '计算机科学与技术', '2025-08-15 15:25:10', '2025-08-15 15:25:10');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (6, 2, 6, 'test1@example.com', '2025-08-15 15:25:10', '2025-08-15 15:25:10');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (7, 2, 7, '13800000003', '2025-08-15 15:25:10', '2025-08-15 15:25:10');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (8, 2, 8, '大三', '2025-08-15 15:25:10', '2025-08-15 15:25:10');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (9, 2, 9, '男', '2025-08-15 15:25:10', '2025-08-15 15:25:10');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (10, 2, 10, '技术部', '2025-08-15 15:25:10', '2025-08-15 15:25:10');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (11, 2, 11, '热爱编程，有良好的团队合作精神', '2025-08-15 15:25:10', '2025-08-15 15:25:10');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (12, 2, 12, '["Java", "Spring Boot", "MySQL", "Redis"]', '2025-08-15 15:25:10', '2025-08-15 15:25:10');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (13, 2, 13, '参与开发学校图书馆管理系统，使用Java Spring Boot框架和MySQL数据库。负责后端接口开发和数据库设计。', '2025-08-15 15:25:10', '2025-08-15 15:25:10');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (34, 2, 14, '工作日下午', '2025-08-15 15:25:10', '2025-08-15 15:25:10');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (35, 2, 15, '/uploads/photos/user2.jpg', '2025-08-15 15:25:10', '2025-08-15 15:25:10');
-
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (14, 3, 4, '测试用户2', '2025-08-15 16:40:20', '2025-08-15 16:40:20');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (15, 3, 5, '软件工程', '2025-08-15 16:40:20', '2025-08-15 16:40:20');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (16, 3, 6, 'test2@example.com', '2025-08-15 16:40:20', '2025-08-15 16:40:20');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (17, 3, 7, '13800000004', '2025-08-15 16:40:20', '2025-08-15 16:40:20');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (18, 3, 8, '大二', '2025-08-15 16:40:20', '2025-08-15 16:40:20');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (19, 3, 9, '女', '2025-08-15 16:40:20', '2025-08-15 16:40:20');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (20, 3, 10, '设计部', '2025-08-15 16:40:20', '2025-08-15 16:40:20');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (21, 3, 11, '对UI设计有浓厚兴趣，熟练使用各类设计软件', '2025-08-15 16:40:20', '2025-08-15 16:40:20');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (22, 3, 12, '["Photoshop", "Illustrator", "Figma", "HTML", "CSS"]', '2025-08-15 16:40:20', '2025-08-15 16:40:20');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (23, 3, 13, '设计学校官方网站界面，使用Figma进行UI设计，并使用HTML/CSS实现部分页面。', '2025-08-15 16:40:20', '2025-08-15 16:40:20');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (36, 3, 14, '周末全天', '2025-08-15 16:40:20', '2025-08-15 16:40:20');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (37, 3, 15, '/uploads/photos/user3.jpg', '2025-08-15 16:40:20', '2025-08-15 16:40:20');
-
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (24, 4, 4, '测试用户3', '2025-08-15 17:10:30', '2025-08-15 17:10:30');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (25, 4, 5, '数据科学与大数据技术', '2025-08-15 17:10:30', '2025-08-15 17:10:30');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (26, 4, 6, 'test3@example.com', '2025-08-15 17:10:30', '2025-08-15 17:10:30');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (27, 4, 7, '13800000005', '2025-08-15 17:10:30', '2025-08-15 17:10:30');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (28, 4, 8, '大四', '2025-08-15 17:10:30', '2025-08-15 17:10:30');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (29, 4, 9, '男', '2025-08-15 17:10:30', '2025-08-15 17:10:30');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (30, 4, 10, '市场部', '2025-08-15 17:10:30', '2025-08-15 17:10:30');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (31, 4, 11, '具备良好的沟通能力和数据分析能力，希望能在市场推广方面发挥作用', '2025-08-15 17:10:30', '2025-08-15 17:10:30');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (32, 4, 12, '["Python", "数据分析", "市场分析", "Excel", "Tableau"]', '2025-08-15 17:10:30', '2025-08-15 17:10:30');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (33, 4, 13, '分析学校社团活动参与数据，使用Python进行数据清洗和分析，并用Tableau制作可视化报告。', '2025-08-15 17:10:30', '2025-08-15 17:10:30');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (38, 4, 14, '工作日晚上或周末', '2025-08-15 17:10:30', '2025-08-15 17:10:30');
-INSERT INTO `resume_field_value` (`value_id`, `resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`) VALUES (39, 4, 15, '/uploads/photos/user4.jpg', '2025-08-15 17:10:30', '2025-08-15 17:10:30');
+INSERT INTO `award_experience` (`award_id`, `user_id`, `award_name`, `award_time`, `description`)
+VALUES (1, 2, 'ACM国际大学生程序设计竞赛区域赛银奖', '2024-11-15',
+        '在ACM国际大学生程序设计竞赛区域赛中获得银奖，展现了优秀的编程和团队协作能力');
+INSERT INTO `award_experience` (`award_id`, `user_id`, `award_name`, `award_time`, `description`)
+VALUES (2, 3, '全国大学生数学建模竞赛二等奖', '2024-09-20',
+        '在全国大学生数学建模竞赛中获得二等奖，体现了扎实的数学基础和建模能力');
+INSERT INTO `award_experience` (`award_id`, `user_id`, `award_name`, `award_time`, `description`)
+VALUES (3, 4, '校级优秀学生干部', '2024-12-01', '因在学生组织中的出色表现获得校级优秀学生干部称号');
+INSERT INTO `award_experience` (`award_id`, `user_id`, `award_name`, `award_time`, `description`)
+VALUES (4, 5, '全国大学生英语竞赛三等奖', '2024-05-10', '在全国大学生英语竞赛中获得三等奖，展现了良好的英语水平');
+INSERT INTO `award_experience` (`award_id`, `user_id`, `award_name`, `award_time`, `description`)
+VALUES (5, 6, '校级三好学生', '2024-12-01', '因学业和综合素质优秀获得校级三好学生称号');
+INSERT INTO `award_experience` (`award_id`, `user_id`, `award_name`, `award_time`, `description`)
+VALUES (6, 7, 'UI设计大赛一等奖', '2024-06-15', '在校级UI设计大赛中获得一等奖');
+INSERT INTO `award_experience` (`award_id`, `user_id`, `award_name`, `award_time`, `description`)
+VALUES (7, 8, '市场营销策划大赛三等奖', '2024-05-10', '在省级市场营销策划大赛中获得三等奖');
 
 -- ----------------------------
 -- Table structure for user
 -- ----------------------------
 DROP TABLE IF EXISTS `user`;
-CREATE TABLE `user`  (
-  `user_id` int NOT NULL AUTO_INCREMENT,
-  `username` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `password` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `role` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL DEFAULT NULL,
-  `email` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `phone` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL DEFAULT NULL,
-  `dept` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL DEFAULT NULL,
-  `create_time` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
-  `status` tinyint(1) NULL DEFAULT 0,
-  `is_member` tinyint(1) NULL DEFAULT 0,
-  `avatar` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL DEFAULT NULL,
-  PRIMARY KEY (`user_id`) USING BTREE,
-  UNIQUE INDEX `username`(`username` ASC) USING BTREE,
-  UNIQUE INDEX `email`(`email` ASC) USING BTREE
-) ENGINE = InnoDB AUTO_INCREMENT = 4 CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci ROW_FORMAT = Dynamic;
+CREATE TABLE `user`
+(
+    `user_id`     int                                                           NOT NULL AUTO_INCREMENT,
+    `username`    varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+    `password`    varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+    `role`        varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+    `name`        varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL DEFAULT NULL,
+    `email`       varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+    `phone`       varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL DEFAULT NULL,
+    `major`       varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL DEFAULT NULL COMMENT '专业',
+    `github`      varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL DEFAULT NULL COMMENT 'GitHub地址',
+    `dept`        varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL DEFAULT NULL,
+    `create_time` timestamp                                                     NULL DEFAULT CURRENT_TIMESTAMP,
+    `status`      tinyint(1)                                                    NULL DEFAULT 0,
+    `is_member`   tinyint(1)                                                    NULL DEFAULT 0,
+    `avatar`      varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL DEFAULT NULL,
+    PRIMARY KEY (`user_id`) USING BTREE,
+    UNIQUE INDEX `username` (`username` ASC) USING BTREE,
+    UNIQUE INDEX `email` (`email` ASC) USING BTREE
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 4
+  CHARACTER SET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci
+  ROW_FORMAT = Dynamic;
 
 -- ----------------------------
 -- Records of user
 -- ----------------------------
-INSERT INTO `user` (`user_id`, `username`, `password`, `role`, `name`, `email`, `phone`, `dept`, `create_time`, `status`, `is_member`, `avatar`) VALUES (1, 'admin', '$2a$10$UO3ZwFXZIkGeG8nqQZRR7.iHL7QtapfHoOuqHc8CRhPxMwxKuJbry', 'ADMIN', '管理员', 'admin@boyuan.club', '13800000000', '技术部', '2025-08-15 13:13:58', 1, 1, NULL);
-INSERT INTO `user` (`user_id`, `username`, `password`, `role`, `name`, `email`, `phone`, `dept`, `create_time`, `status`, `is_member`, `avatar`) VALUES (2, 'student1', '$2a$10$UO3ZwFXZIkGeG8nqQZRR7.iHL7QtapfHoOuqHc8CRhPxMwxKuJbry', 'USER', '学生1', '1234567890@stu.ecnu.edu.cn', '13800000001', '媒体部', '2025-08-15 13:13:58', 1, 1, '/uploads/avatars/107194c0-f53f-4aac-9671-fadd281f9669.png');
-INSERT INTO `user` (`user_id`, `username`, `password`, `role`, `name`, `email`, `phone`, `dept`, `create_time`, `status`, `is_member`, `avatar`) VALUES (3, 'student2', '$2a$10$UO3ZwFXZIkGeG8nqQZRR7.iHL7QtapfHoOuqHc8CRhPxMwxKuJbry', 'USER', '学生2', '0987654321@stu.ecnu.edu.cn', '13800000002', '综合部', '2025-08-15 13:13:58', 1, 1, NULL);
+INSERT INTO `user`
+VALUES (1, 'admin', '$2a$10$UfOo2mtqbSKOA3yB4F4Ci.54uoNzvFMW2VznfkpXKraHL.e9VBWdC', 'ADMIN', '管理员',
+        'admin@stu.ecnu.edu.cn', '13800000000', '计算机科学与技术', 'https://github.com/admin', '技术部',
+        '2025-08-15 14:57:57', 1, 1, '/uploads/avatars/admin.jpg');
+INSERT INTO `user`
+VALUES (2, 'testuser1', '$2a$10$UfOo2mtqbSKOA3yB4F4Ci.54uoNzvFMW2VznfkpXKraHL.e9VBWdC', 'USER', '测试用户1',
+        'testuser1@stu.ecnu.edu.cn', '13800000001', '软件工程', 'https://github.com/testuser1', '技术部',
+        '2025-08-15 14:57:57', 1, 0, '/uploads/avatars/user1.jpg');
+INSERT INTO `user`
+VALUES (3, 'testuser2', '$2a$10$UfOo2mtqbSKOA3yB4F4Ci.54uoNzvFMW2VznfkpXKraHL.e9VBWdC', 'USER', '测试用户2',
+        'testuser2@stu.ecnu.edu.cn', '13800000002', '数据科学与大数据技术', 'https://github.com/testuser2', '设计部',
+        '2025-08-15 14:57:57', 1, 0, '/uploads/avatars/user2.jpg');
+INSERT INTO `user`
+VALUES (4, 'student1', '$2a$10$UfOo2mtqbSKOA3yB4F4Ci.54uoNzvFMW2VznfkpXKraHL.e9VBWdC', 'USER', '张三',
+        'student1@stu.ecnu.edu.cn', '13800000003', '计算机科学与技术', 'https://github.com/zhangsan', '技术部',
+        '2025-08-15 15:20:00', 1, 0, '/uploads/avatars/student1.jpg');
+INSERT INTO `user`
+VALUES (5, 'student2', '$2a$10$UfOo2mtqbSKOA3yB4F4Ci.54uoNzvFMW2VznfkpXKraHL.e9VBWdC', 'USER', '李四',
+        'student2@stu.ecnu.edu.cn', '13800000004', '数字媒体技术', 'https://github.com/lisi', '设计部',
+        '2025-08-15 16:35:10', 1, 0, '/uploads/avatars/student2.jpg');
+INSERT INTO `user`
+VALUES (6, 'student3', '$2a$10$UfOo2mtqbSKOA3yB4F4Ci.54uoNzvFMW2VznfkpXKraHL.e9VBWdC', 'USER', '王五',
+        'student3@stu.ecnu.edu.cn', '13800000005', '市场营销', 'https://github.com/wangwu', '市场部',
+        '2025-08-15 17:05:20', 1, 0, '/uploads/avatars/student3.jpg');
+INSERT INTO `user`
+VALUES (7, 'student4', '$2a$10$UfOo2mtqbSKOA3yB4F4Ci.54uoNzvFMW2VznfkpXKraHL.e9VBWdC', 'USER', '赵六',
+        'student4@stu.ecnu.edu.cn', '13800000006', '软件工程', 'https://github.com/zhaoliu', '技术部',
+        '2025-08-15 17:30:30', 1, 0, '/uploads/avatars/student4.jpg');
+INSERT INTO `user`
+VALUES (8, 'student5', '$2a$10$UfOo2mtqbSKOA3yB4F4Ci.54uoNzvFMW2VznfkpXKraHL.e9VBWdC', 'USER', '钱七',
+        'student5@stu.ecnu.edu.cn', '13800000007', '视觉传达设计', 'https://github.com/qianqi', '设计部',
+        '2025-08-15 17:45:40', 1, 0, '/uploads/avatars/student5.jpg');
+INSERT INTO `user`
+VALUES (9, 'student6', '$2a$10$UfOo2mtqbSKOA3yB4F4Ci.54uoNzvFMW2VznfkpXKraHL.e9VBWdC', 'USER', '孙八',
+        'student6@stu.ecnu.edu.cn', '13800000008', '数据科学与大数据技术', 'https://github.com/sunba', '技术部',
+        '2025-08-15 18:00:50', 1, 0, '/uploads/avatars/student6.jpg');
 
--- 添加更多测试用户
-INSERT INTO `user` (`user_id`, `username`, `password`, `role`, `name`, `email`, `phone`, `dept`, `create_time`, `status`, `is_member`, `avatar`) VALUES (4, 'testuser1', '$2a$10$UO3ZwFXZIkGeG8nqQZRR7.iHL7QtapfHoOuqHc8CRhPxMwxKuJbry', 'USER', '测试用户1', 'test1@example.com', '13800000003', '技术部', '2025-08-15 18:00:00', 1, 1, NULL);
-INSERT INTO `user` (`user_id`, `username`, `password`, `role`, `name`, `email`, `phone`, `dept`, `create_time`, `status`, `is_member`, `avatar`) VALUES (5, 'testuser2', '$2a$10$UO3ZwFXZIkGeG8nqQZRR7.iHL7QtapfHoOuqHc8CRhPxMwxKuJbry', 'USER', '测试用户2', 'test2@example.com', '13800000004', '设计部', '2025-08-15 18:00:00', 1, 0, NULL);
-INSERT INTO `user` (`user_id`, `username`, `password`, `role`, `name`, `email`, `phone`, `dept`, `create_time`, `status`, `is_member`, `avatar`) VALUES (6, 'testuser3', '$2a$10$UO3ZwFXZIkGeG8nqQZRR7.iHL7QtapfHoOuqHc8CRhPxMwxKuJbry', 'USER', '测试用户3', 'test3@example.com', '13800000005', '市场部', '2025-08-15 18:00:00', 1, 1, NULL);
+-- ----------------------------
+-- Table structure for resume
+-- ----------------------------
+DROP TABLE IF EXISTS `resume`;
+CREATE TABLE `resume`
+(
+    `resume_id`    int       NOT NULL AUTO_INCREMENT,
+    `user_id`      int       NOT NULL,
+    `cycle_id`     int       NOT NULL,
+    `status`       tinyint   NOT NULL DEFAULT 1 COMMENT '简历状态: 1(草稿), 2(已提交), 3(评审中), 4(通过), 5(未通过)',
+    `submitted_at` timestamp NULL     DEFAULT NULL COMMENT '提交时间',
+    `created_at`   timestamp NULL     DEFAULT CURRENT_TIMESTAMP,
+    `updated_at`   timestamp NULL     DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`resume_id`) USING BTREE,
+    UNIQUE INDEX `uk_user_cycle` (`user_id`, `cycle_id`) USING BTREE,
+    INDEX `idx_user_id` (`user_id` ASC) USING BTREE,
+    INDEX `idx_cycle_id` (`cycle_id` ASC) USING BTREE,
+    CONSTRAINT `resume_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `user` (`user_id`) ON DELETE CASCADE ON UPDATE RESTRICT,
+    CONSTRAINT `resume_ibfk_2` FOREIGN KEY (`cycle_id`) REFERENCES `recruitment_cycle` (`cycle_id`) ON DELETE RESTRICT ON UPDATE RESTRICT
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 4
+  CHARACTER SET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci
+  ROW_FORMAT = Dynamic;
+
+-- ----------------------------
+-- Records of resume
+-- ----------------------------
+INSERT INTO `resume` (`resume_id`, `user_id`, `cycle_id`, `status`, `submitted_at`, `created_at`, `updated_at`)
+VALUES (2, 4, 2, 2, '2025-08-15 15:30:00', '2025-08-15 15:25:10', '2025-08-15 15:30:00');
+INSERT INTO `resume` (`resume_id`, `user_id`, `cycle_id`, `status`, `submitted_at`, `created_at`, `updated_at`)
+VALUES (3, 5, 2, 1, '2025-08-15 16:45:00', '2025-08-15 16:40:20', '2025-08-15 16:45:00');
+INSERT INTO `resume` (`resume_id`, `user_id`, `cycle_id`, `status`, `submitted_at`, `created_at`, `updated_at`)
+VALUES (4, 6, 2, 3, '2025-08-15 17:15:00', '2025-08-15 17:10:30', '2025-08-15 17:20:00');
+
+-- 为更多用户添加简历
+INSERT INTO `resume` (`user_id`, `cycle_id`, `status`, `submitted_at`, `created_at`, `updated_at`)
+VALUES (7, 2, 1, NULL, '2025-08-15 17:35:00', '2025-08-15 17:35:00'),
+       (8, 2, 2, '2025-08-15 17:50:00', '2025-08-15 17:45:00', '2025-08-15 17:50:00'),
+       (9, 2, 4, '2025-08-15 18:05:00', '2025-08-15 18:00:00', '2025-08-15 18:10:00');
+
+-- ----------------------------
+-- Table structure for resume_field_definition
+-- ----------------------------
+DROP TABLE IF EXISTS `resume_field_definition`;
+CREATE TABLE `resume_field_definition`
+(
+    `field_id`    int                                                           NOT NULL AUTO_INCREMENT,
+    `cycle_id`    int                                                           NOT NULL,
+    `field_key`   varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci  NOT NULL,
+    `field_label` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+    `is_required` tinyint(1)                                                    NULL DEFAULT 0,
+    `sort_order`  int                                                           NULL DEFAULT 0,
+    `is_active`   tinyint(1)                                                    NULL DEFAULT 1,
+    `created_at`  timestamp                                                     NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at`  timestamp                                                     NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`field_id`) USING BTREE,
+    INDEX `idx_cycle_id` (`cycle_id` ASC) USING BTREE,
+    CONSTRAINT `resume_field_definition_ibfk_1` FOREIGN KEY (`cycle_id`) REFERENCES `recruitment_cycle` (`cycle_id`) ON DELETE RESTRICT ON UPDATE RESTRICT
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 4
+  CHARACTER SET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci
+  ROW_FORMAT = Dynamic;
+
+-- ----------------------------
+-- Records of resume_field_definition
+-- ----------------------------
+-- 删除2024年的简历字段定义
+
+-- 2025年份的简历字段定义（更新后的版本）
+INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`,
+                                       `is_active`, `created_at`, `updated_at`)
+VALUES (4, 2, 'name', '姓名', 1, 1, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00');
+INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`,
+                                       `is_active`, `created_at`, `updated_at`)
+VALUES (5, 2, 'major', '专业', 1, 2, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00');
+INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`,
+                                       `is_active`, `created_at`, `updated_at`)
+VALUES (6, 2, 'email', '邮箱', 1, 3, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00');
+INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`,
+                                       `is_active`, `created_at`, `updated_at`)
+VALUES (7, 2, 'phone', '手机号', 1, 4, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00');
+INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`,
+                                       `is_active`, `created_at`, `updated_at`)
+VALUES (8, 2, 'grade', '年级', 1, 5, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00');
+INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`,
+                                       `is_active`, `created_at`, `updated_at`)
+VALUES (9, 2, 'gender', '性别', 1, 6, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00');
+INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`,
+                                       `is_active`, `created_at`, `updated_at`)
+VALUES (10, 2, 'expected_departments', '期望部门', 1, 7, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00');
+INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`,
+                                       `is_active`, `created_at`, `updated_at`)
+VALUES (11, 2, 'self_introduction', '自我介绍', 1, 8, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00');
+INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`,
+                                       `is_active`, `created_at`, `updated_at`)
+VALUES (12, 2, 'tech_stack', '技术栈', 1, 9, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00');
+INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`,
+                                       `is_active`, `created_at`, `updated_at`)
+VALUES (13, 2, 'project_experience', '项目经验', 1, 10, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00');
+INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`,
+                                       `is_active`, `created_at`, `updated_at`)
+VALUES (14, 2, 'expected_interview_time', '期望的面试时间', 0, 11, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00');
+INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`,
+                                       `is_active`, `created_at`, `updated_at`)
+VALUES (15, 2, 'personal_photo', '个人照片', 0, 12, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00');
+INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`,
+                                       `is_active`, `created_at`, `updated_at`)
+VALUES (16, 2, 'student_id', '学号', 1, 0, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00');
+INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`,
+                                       `is_active`, `created_at`, `updated_at`)
+VALUES (17, 2, 'introduction', '个人简介', 1, 13, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00');
+INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`,
+                                       `is_active`, `created_at`, `updated_at`)
+VALUES (18, 2, 'reason', '加入理由', 1, 14, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00');
+INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`,
+                                       `is_active`, `created_at`, `updated_at`)
+VALUES (19, 2, 'github', 'GitHub地址', 0, 15, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00');
+INSERT INTO `resume_field_definition` (`field_id`, `cycle_id`, `field_key`, `field_label`, `is_required`, `sort_order`,
+                                       `is_active`, `created_at`, `updated_at`)
+VALUES (20, 2, 'github_url', 'GitHub地址', 0, 16, 1, '2025-08-15 18:00:00', '2025-08-15 18:00:00');
+
+-- ----------------------------
+-- Table structure for resume_field_value
+-- ----------------------------
+DROP TABLE IF EXISTS `resume_field_value`;
+CREATE TABLE `resume_field_value`
+(
+    `value_id`    int                                                   NOT NULL AUTO_INCREMENT,
+    `resume_id`   int                                                   NOT NULL,
+    `field_id`    int                                                   NOT NULL,
+    `field_value` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL,
+    `created_at`  timestamp                                             NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at`  timestamp                                             NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`value_id`) USING BTREE,
+    INDEX `resume_id` (`resume_id` ASC) USING BTREE,
+    INDEX `field_id` (`field_id` ASC) USING BTREE,
+    CONSTRAINT `resume_field_value_ibfk_1` FOREIGN KEY (`resume_id`) REFERENCES `resume` (`resume_id`) ON DELETE CASCADE ON UPDATE RESTRICT,
+    CONSTRAINT `resume_field_value_ibfk_2` FOREIGN KEY (`field_id`) REFERENCES `resume_field_definition` (`field_id`) ON DELETE RESTRICT ON UPDATE RESTRICT
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 4
+  CHARACTER SET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci
+  ROW_FORMAT = Dynamic;
+
+-- ----------------------------
+-- Records of resume_field_value
+-- ----------------------------
+-- 删除2024年的简历字段值
+-- 保留并更新2025年的简历字段值
+
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (2, 4, '测试用户1', '2025-08-15 15:25:10', '2025-08-15 15:25:10');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (2, 5, '计算机科学与技术', '2025-08-15 15:25:10', '2025-08-15 15:25:10');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (2, 6, 'testuser1@stu.ecnu.edu.cn', '2025-08-15 15:25:10', '2025-08-15 15:25:10');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (2, 7, '13800000003', '2025-08-15 15:25:10', '2025-08-15 15:25:10');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (2, 8, '大三', '2025-08-15 15:25:10', '2025-08-15 15:25:10');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (2, 9, '男', '2025-08-15 15:25:10', '2025-08-15 15:25:10');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (2, 10, '["技术部"]', '2025-08-15 15:25:10', '2025-08-15 15:25:10');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (2, 11, '热爱编程，有良好的团队合作精神', '2025-08-15 15:25:10', '2025-08-15 15:25:10');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (2, 12, '["Java", "Spring Boot", "MySQL", "Redis"]', '2025-08-15 15:25:10', '2025-08-15 15:25:10');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (2, 13, '参与开发学校图书馆管理系统，使用Java Spring Boot框架和MySQL数据库。负责后端接口开发和数据库设计。',
+        '2025-08-15 15:25:10', '2025-08-15 15:25:10');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (2, 14, '工作日下午', '2025-08-15 15:25:10', '2025-08-15 15:25:10');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (2, 15, '/uploads/photos/user2.jpg', '2025-08-15 15:25:10', '2025-08-15 15:25:10');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (2, 16, '202312345678901', '2025-08-15 15:25:10', '2025-08-15 15:25:10');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (2, 17, '我是一个对技术充满热情的学生，希望能在技术部门学习和成长', '2025-08-15 15:25:10', '2025-08-15 15:25:10');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (2, 18, '希望提升自己的技术能力，同时为社团发展贡献力量', '2025-08-15 15:25:10', '2025-08-15 15:25:10');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (2, 19, 'https://github.com/testuser1', '2025-08-15 15:25:10', '2025-08-15 15:25:10');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (2, 20, 'https://github.com/testuser1', '2025-08-15 15:25:10', '2025-08-15 15:25:10');
+
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (3, 4, '测试用户2', '2025-08-15 16:40:20', '2025-08-15 16:40:20');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (3, 5, '软件工程', '2025-08-15 16:40:20', '2025-08-15 16:40:20');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (3, 6, 'testuser2@stu.ecnu.edu.cn', '2025-08-15 16:40:20', '2025-08-15 16:40:20');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (3, 7, '13800000004', '2025-08-15 16:40:20', '2025-08-15 16:40:20');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (3, 8, '大二', '2025-08-15 16:40:20', '2025-08-15 16:40:20');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (3, 9, '女', '2025-08-15 16:40:20', '2025-08-15 16:40:20');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (3, 10, '["设计部"]', '2025-08-15 16:40:20', '2025-08-15 16:40:20');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (3, 11, '对UI设计有浓厚兴趣，熟练使用各类设计软件', '2025-08-15 16:40:20', '2025-08-15 16:40:20');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (3, 12, '["Photoshop", "Illustrator", "Figma", "HTML", "CSS"]', '2025-08-15 16:40:20', '2025-08-15 16:40:20');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (3, 13, '设计学校官方网站界面，使用Figma进行UI设计，并使用HTML/CSS实现部分页面。', '2025-08-15 16:40:20',
+        '2025-08-15 16:40:20');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (3, 14, '周末全天', '2025-08-15 16:40:20', '2025-08-15 16:40:20');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (3, 15, '/uploads/photos/user3.jpg', '2025-08-15 16:40:20', '2025-08-15 16:40:20');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (3, 16, '202212345678902', '2025-08-15 16:40:20', '2025-08-15 16:40:20');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (3, 17, '我是一个创意丰富的设计师，希望能在设计部发挥自己的才能', '2025-08-15 16:40:20', '2025-08-15 16:40:20');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (3, 18, '希望通过参与社团活动提升设计能力，结识志同道合的朋友', '2025-08-15 16:40:20', '2025-08-15 16:40:20');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (3, 19, 'https://github.com/testuser2', '2025-08-15 16:40:20', '2025-08-15 16:40:20');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (3, 20, 'https://github.com/testuser2', '2025-08-15 16:40:20', '2025-08-15 16:40:20');
+
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (4, 4, '测试用户3', '2025-08-15 17:10:30', '2025-08-15 17:10:30');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (4, 5, '数据科学与大数据技术', '2025-08-15 17:10:30', '2025-08-15 17:10:30');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (4, 6, 'testuser3@stu.ecnu.edu.cn', '2025-08-15 17:10:30', '2025-08-15 17:10:30');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (4, 7, '13800000005', '2025-08-15 17:10:30', '2025-08-15 17:10:30');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (4, 8, '大四', '2025-08-15 17:10:30', '2025-08-15 17:10:30');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (4, 9, '男', '2025-08-15 17:10:30', '2025-08-15 17:10:30');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (4, 10, '["市场部"]', '2025-08-15 17:10:30', '2025-08-15 17:10:30');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (4, 11, '具备良好的沟通能力和数据分析能力，希望能在市场推广方面发挥作用', '2025-08-15 17:10:30',
+        '2025-08-15 17:10:30');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (4, 12, '["Python", "数据分析", "市场分析", "Excel", "Tableau"]', '2025-08-15 17:10:30', '2025-08-15 17:10:30');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (4, 13, '分析学校社团活动参与数据，使用Python进行数据清洗和分析，并用Tableau制作可视化报告。',
+        '2025-08-15 17:10:30', '2025-08-15 17:10:30');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (4, 14, '工作日晚上或周末', '2025-08-15 17:10:30', '2025-08-15 17:10:30');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (4, 15, '/uploads/photos/user4.jpg', '2025-08-15 17:10:30', '2025-08-15 17:10:30');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (4, 16, '202112345678903', '2025-08-15 17:10:30', '2025-08-15 17:10:30');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (4, 17, '我是一个善于沟通和策划的学生，希望能在市场部发挥作用', '2025-08-15 17:10:30', '2025-08-15 17:10:30');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (4, 18, '希望通过参与社团活动提升市场运营能力，为社团发展贡献力量', '2025-08-15 17:10:30', '2025-08-15 17:10:30');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (4, 19, 'https://github.com/testuser3', '2025-08-15 17:10:30', '2025-08-15 17:10:30');
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`, `created_at`, `updated_at`)
+VALUES (4, 20, 'https://github.com/testuser3', '2025-08-15 17:10:30', '2025-08-15 17:10:30');
+
+-- 添加更多简历字段值
+INSERT INTO `resume_field_value` (`resume_id`, `field_id`, `field_value`)
+VALUES (5, 4, '张三'),
+       (5, 5, '计算机科学与技术'),
+       (5, 6, 'student3@stu.ecnu.edu.cn'),
+       (5, 7, '13800000006'),
+       (5, 8, '大二'),
+       (5, 9, '男'),
+       (5, 10, '["技术部","设计部"]'),
+       (5, 11, '热爱编程和开源技术，有良好的团队协作能力'),
+       (5, 12, '["Java", "Python", "Linux", "Docker"]'),
+       (5, 13, '参与学校开源社区项目，贡献代码并维护文档'),
+       (5, 14, '2025-09-15 14:00:00'),
+       (5, 15, '/uploads/photos/student3.jpg'),
+       (5, 16, '202312345678901'),
+       (5, 17, '我是一个对技术充满热情的学生，希望能在技术部门学习和成长'),
+       (5, 18, '希望提升自己的技术能力，同时为社团发展贡献力量'),
+       (5, 19, 'https://github.com/zhangsan'),
+       (5, 20, 'https://github.com/zhangsan'),
+
+       (6, 4, '李四'),
+       (6, 5, '数字媒体技术'),
+       (6, 6, 'student4@stu.ecnu.edu.cn'),
+       (6, 7, '13800000007'),
+       (6, 8, '大三'),
+       (6, 9, '女'),
+       (6, 10, '["设计部","市场部"]'),
+       (6, 11, '热爱设计和艺术，有独特的审美和创意能力'),
+       (6, 12, '["Photoshop", "Illustrator", "Figma", "After Effects"]'),
+       (6, 13, '设计学校宣传海报和活动物料，参与多个设计项目'),
+       (6, 14, '2025-09-16 10:00:00'),
+       (6, 15, '/uploads/photos/student4.jpg'),
+       (6, 16, '202212345678902'),
+       (6, 17, '我是一个创意丰富的设计师，希望能在设计部发挥自己的才能'),
+       (6, 18, '希望通过参与社团活动提升设计能力，结识志同道合的朋友'),
+       (6, 19, 'https://github.com/lisi'),
+       (6, 20, 'https://github.com/lisi'),
+
+       (7, 4, '王五'),
+       (7, 5, '市场营销'),
+       (7, 6, 'student5@stu.ecnu.edu.cn'),
+       (7, 7, '13800000008'),
+       (7, 8, '大四'),
+       (7, 9, '男'),
+       (7, 10, '["市场部","技术部"]'),
+       (7, 11, '具备良好的沟通能力和市场洞察力，善于团队协作'),
+       (7, 12, '["市场分析", "数据处理", "活动策划", "演讲"]'),
+       (7, 13, '策划并执行学校多项营销活动，取得良好效果'),
+       (7, 14, '2025-09-17 15:00:00'),
+       (7, 15, '/uploads/photos/student5.jpg'),
+       (7, 16, '202112345678903'),
+       (7, 17, '我是一个善于沟通和策划的学生，希望能在市场部发挥作用'),
+       (7, 18, '希望通过参与社团活动提升市场运营能力，为社团发展贡献力量'),
+       (7, 19, 'https://github.com/wangwu'),
+       (7, 20, 'https://github.com/wangwu');
 
 SET FOREIGN_KEY_CHECKS = 1;

--- a/src/main/resources/mapper/RecruitmentCycleMapper.xml
+++ b/src/main/resources/mapper/RecruitmentCycleMapper.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="club.boyuan.official.mapper.RecruitmentCycleMapper">
+
+    <resultMap id="RecruitmentCycleResultMap" type="club.boyuan.official.entity.RecruitmentCycle">
+        <id property="cycleId" column="cycle_id"/>
+        <result property="cycleName" column="cycle_name"/>
+        <result property="description" column="description"/>
+        <result property="startDate" column="start_date"/>
+        <result property="endDate" column="end_date"/>
+        <result property="academicYear" column="academic_year"/>
+        <result property="status" column="status"/>
+        <result property="isActive" column="is_active"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="updatedAt" column="updated_at"/>
+    </resultMap>
+
+    <insert id="insert" parameterType="club.boyuan.official.entity.RecruitmentCycle" useGeneratedKeys="true" keyProperty="cycleId">
+        INSERT INTO recruitment_cycle (cycle_name, description, start_date, end_date, academic_year, status, is_active, created_at, updated_at)
+        VALUES (#{cycleName}, #{description}, #{startDate}, #{endDate}, #{academicYear}, #{status, jdbcType=INTEGER}, #{isActive, jdbcType=INTEGER}, NOW(), NOW())
+    </insert>
+
+    <update id="update" parameterType="club.boyuan.official.entity.RecruitmentCycle">
+        UPDATE recruitment_cycle
+        <set>
+            <if test="cycleName != null and cycleName != ''">
+                cycle_name = #{cycleName},
+            </if>
+            <if test="description != null and description != ''">
+                description = #{description},
+            </if>
+            <if test="startDate != null">
+                start_date = #{startDate},
+            </if>
+            <if test="endDate != null">
+                end_date = #{endDate},
+            </if>
+            <if test="academicYear != null and academicYear != ''">
+                academic_year = #{academicYear},
+            </if>
+            <if test="status != null">
+                status = #{status},
+            </if>
+            <if test="isActive != null">
+                is_active = #{isActive},
+            </if>
+            updated_at = NOW()
+        </set>
+        WHERE cycle_id = #{cycleId}
+    </update>
+
+    <delete id="deleteById">
+        DELETE FROM recruitment_cycle WHERE cycle_id = #{cycleId}
+    </delete>
+
+    <select id="findById" resultMap="RecruitmentCycleResultMap">
+        SELECT * FROM recruitment_cycle WHERE cycle_id = #{cycleId}
+    </select>
+
+    <select id="findAll" resultMap="RecruitmentCycleResultMap">
+        SELECT * FROM recruitment_cycle ORDER BY created_at DESC
+    </select>
+
+    <select id="findByStatus" resultMap="RecruitmentCycleResultMap">
+        SELECT * FROM recruitment_cycle WHERE status = #{status} ORDER BY created_at DESC
+    </select>
+
+    <select id="findByIsActive" resultMap="RecruitmentCycleResultMap">
+        SELECT * FROM recruitment_cycle WHERE is_active = #{isActive} ORDER BY created_at DESC
+    </select>
+
+    <select id="findByAcademicYear" resultMap="RecruitmentCycleResultMap">
+        SELECT * FROM recruitment_cycle WHERE academic_year = #{academicYear}
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -11,6 +11,8 @@
             <if test="role != null">role,</if>
             <if test="name != null">name,</if>
             <if test="phone != null">phone,</if>
+            <if test="major != null">major,</if>
+            <if test="github != null">github,</if>
             <if test="dept != null">dept,</if>
             <if test="avatar != null">avatar,</if>
             create_time,
@@ -25,6 +27,8 @@
             <if test="role != null">#{role},</if>
             <if test="name != null">#{name},</if>
             <if test="phone != null">#{phone},</if>
+            <if test="major != null">#{major},</if>
+            <if test="github != null">#{github},</if>
             <if test="dept != null">#{dept},</if>
             <if test="avatar != null">#{avatar},</if>
             NOW(),
@@ -41,6 +45,8 @@
                role,
                name,
                phone,
+               major,
+               github,
                dept,
                avatar,
                create_time,
@@ -58,6 +64,8 @@
                role,
                name,
                phone,
+               major,
+               github,
                dept,
                avatar,
                create_time,
@@ -75,6 +83,8 @@
                role,
                name,
                phone,
+               major,
+               github,
                dept,
                avatar,
                create_time,
@@ -92,6 +102,8 @@
                role,
                name,
                phone,
+               major,
+               github,
                dept,
                avatar,
                create_time,
@@ -110,6 +122,8 @@
             <if test="role != null">role = #{role},</if>
             <if test="name != null">name = #{name},</if>
             <if test="phone != null">phone = #{phone},</if>
+            <if test="major != null">major = #{major},</if>
+            <if test="github != null">github = #{github},</if>
             <if test="dept != null">dept = #{dept},</if>
             <if test="avatar != null">avatar = #{avatar},</if>
             <if test="status != null">status = #{status},</if>
@@ -138,6 +152,8 @@
                role,
                name,
                phone,
+               major,
+               github,
                dept,
                avatar,
                create_time,
@@ -147,7 +163,8 @@
     </select>
 
     <select id="findByRoleAndDeptAndStatus" resultType="club.boyuan.official.entity.User">
-        SELECT user_id, username, password, email, role, name, phone, dept, avatar, create_time, status, is_member FROM user
+        SELECT user_id, username, password, email, role, name, phone, dept, avatar, create_time, status, is_member
+        FROM user
         <where>
             <if test="role != null and role != ''">
                 AND role = #{role}
@@ -186,6 +203,8 @@
                role,
                name,
                phone,
+               major,
+               github,
                dept,
                avatar,
                create_time,


### PR DESCRIPTION
- 新增招募周期实体类、Mapper、Service和Controller，提供完整的CRUD操作
- 修改数据库结构，将cycle_id改为自增ID并移除academic_year唯一约束
- 在User实体中添加major和github字段以支持用户专业和GitHub信息
- 完善Resume实体中的status字段注释，明确各状态含义
- 添加权限控制，确保只有管理员可以创建、更新和删除招募周期
- 实现完整的异常处理机制和日志记录
- 更新数据库初始化脚本，使用加密密码并添加测试数据