### PR TITLE
ci: 修复集成测试无依赖导致的 CI 失败（挂服务容器）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 # PR 与非 main 分支推送时跑测试 + 覆盖率，作为质量门禁。
+# @SpringBootTest 会启动完整容器（Flyway 迁移 + Redis + RabbitMQ），
+# 因此为 CI 挂上 MySQL/Redis/RabbitMQ 服务容器，全新空库由 Flyway 从零迁移。
 on:
   pull_request:
   push:
@@ -11,6 +13,48 @@ jobs:
   test:
     name: Build & Test & Coverage
     runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: official
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval=10s --health-timeout=5s --health-retries=15
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=10s --health-timeout=5s --health-retries=10
+      rabbitmq:
+        image: rabbitmq:3-management
+        env:
+          RABBITMQ_DEFAULT_USER: root
+          RABBITMQ_DEFAULT_PASS: root
+        ports:
+          - 5672:5672
+        options: >-
+          --health-cmd="rabbitmq-diagnostics -q ping"
+          --health-interval=10s --health-timeout=10s --health-retries=15
+
+    env:
+      # 指向上面的服务容器（datasource url 用 localhost:${MYSQL_PORT}/official）
+      MYSQL_PORT: 3306
+      DB_USERNAME: root
+      DB_PASSWORD: root
+      RABBITMQ_HOST: localhost
+      RABBITMQ_PORT: 5672
+      RABBITMQ_USERNAME: root
+      RABBITMQ_PASSWORD: root
+      # 仅供测试上下文启动用，非真实密钥（HS256 需足够长度）
+      JWT_SECRET: ci-only-test-secret-not-for-production-0123456789abcdef0123456789
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -15,9 +15,47 @@ env:
 
 jobs:
   # ── 1) 测试门禁：测试不过不发布 ──────────────────────────────
+  # @SpringBootTest 需完整容器(Flyway+Redis+RabbitMQ)，为测试挂服务容器，与 ci.yml 一致。
   test:
     name: Test
     runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: official
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval=10s --health-timeout=5s --health-retries=15
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=10s --health-timeout=5s --health-retries=10
+      rabbitmq:
+        image: rabbitmq:3-management
+        env:
+          RABBITMQ_DEFAULT_USER: root
+          RABBITMQ_DEFAULT_PASS: root
+        ports:
+          - 5672:5672
+        options: >-
+          --health-cmd="rabbitmq-diagnostics -q ping"
+          --health-interval=10s --health-timeout=10s --health-retries=15
+    env:
+      MYSQL_PORT: 3306
+      DB_USERNAME: root
+      DB_PASSWORD: root
+      RABBITMQ_HOST: localhost
+      RABBITMQ_PORT: 5672
+      RABBITMQ_USERNAME: root
+      RABBITMQ_PASSWORD: root
+      JWT_SECRET: ci-only-test-secret-not-for-production-0123456789abcdef0123456789
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## 背景
CI 失败根因：`OfficialApplicationTests` / `UserRoleControllerTest` / `JwtAuthenticationFilterTest` 是 `@SpringBootTest`，会启动完整容器 → Flyway/Hikari 连 MySQL，而 runner 无 DB → `Communications link failure`（纯单测全部通过）。

## 改动
`ci.yml` 的 test job 增加服务容器 + 环境变量：
- MySQL 8（空库 `official`，由 Flyway 从零幂等迁移，V6 已补齐核心表）
- Redis 7、RabbitMQ 3（root/root）
- 注入 `MYSQL_PORT/DB_*/RABBITMQ_*` 与足够长的 `JWT_SECRET`（仅测试用）

## Test plan
- [ ] 本 PR 的 CI 转绿（含覆盖率 Summary）

Made with [Cursor](https://cursor.com)