### PR TITLE
ci: 修复 main 发布流水线（测试门禁挂服务容器）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 # PR 与非 main 分支推送时跑测试 + 覆盖率，作为质量门禁。
+# @SpringBootTest 会启动完整容器（Flyway 迁移 + Redis + RabbitMQ），
+# 因此为 CI 挂上 MySQL/Redis/RabbitMQ 服务容器，全新空库由 Flyway 从零迁移。
 on:
   pull_request:
   push:
@@ -11,6 +13,48 @@ jobs:
   test:
     name: Build & Test & Coverage
     runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: official
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval=10s --health-timeout=5s --health-retries=15
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=10s --health-timeout=5s --health-retries=10
+      rabbitmq:
+        image: rabbitmq:3-management
+        env:
+          RABBITMQ_DEFAULT_USER: root
+          RABBITMQ_DEFAULT_PASS: root
+        ports:
+          - 5672:5672
+        options: >-
+          --health-cmd="rabbitmq-diagnostics -q ping"
+          --health-interval=10s --health-timeout=10s --health-retries=15
+
+    env:
+      # 指向上面的服务容器（datasource url 用 localhost:${MYSQL_PORT}/official）
+      MYSQL_PORT: 3306
+      DB_USERNAME: root
+      DB_PASSWORD: root
+      RABBITMQ_HOST: localhost
+      RABBITMQ_PORT: 5672
+      RABBITMQ_USERNAME: root
+      RABBITMQ_PASSWORD: root
+      # 仅供测试上下文启动用，非真实密钥（HS256 需足够长度）
+      JWT_SECRET: ci-only-test-secret-not-for-production-0123456789abcdef0123456789
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -15,9 +15,47 @@ env:
 
 jobs:
   # ── 1) 测试门禁：测试不过不发布 ──────────────────────────────
+  # @SpringBootTest 需完整容器(Flyway+Redis+RabbitMQ)，为测试挂服务容器，与 ci.yml 一致。
   test:
     name: Test
     runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: official
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval=10s --health-timeout=5s --health-retries=15
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=10s --health-timeout=5s --health-retries=10
+      rabbitmq:
+        image: rabbitmq:3-management
+        env:
+          RABBITMQ_DEFAULT_USER: root
+          RABBITMQ_DEFAULT_PASS: root
+        ports:
+          - 5672:5672
+        options: >-
+          --health-cmd="rabbitmq-diagnostics -q ping"
+          --health-interval=10s --health-timeout=10s --health-retries=15
+    env:
+      MYSQL_PORT: 3306
+      DB_USERNAME: root
+      DB_PASSWORD: root
+      RABBITMQ_HOST: localhost
+      RABBITMQ_PORT: 5672
+      RABBITMQ_USERNAME: root
+      RABBITMQ_PASSWORD: root
+      JWT_SECRET: ci-only-test-secret-not-for-production-0123456789abcdef0123456789
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
把 develop 上已验证的 CI 修复合入 main：ci.yml 与 docker-push.yml 的测试任务挂 MySQL/Redis/RabbitMQ 服务容器。
合并后 docker-push：测试通过 → 构建推镜像 → 双机滚动部署(B→A) → LB 校验。develop CI 已绿。

Made with [Cursor](https://cursor.com)