### PR TITLE
fix(docker): 基础镜像改用 eclipse-temurin:17-jdk-jammy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # 运行阶段
-FROM openjdk:17-jdk-slim
+# 注：openjdk 官方镜像已废弃下架（openjdk:17-jdk-slim 不再可拉取），
+# 改用仍维护的 Eclipse Temurin（同为 Ubuntu/Debian 系，apt-get 与字体包可用）。
+FROM eclipse-temurin:17-jdk-jammy
 
 # 安装字体和必要的依赖
 RUN apt-get update && \


### PR DESCRIPTION
openjdk 官方镜像已废弃下架，openjdk:17-jdk-slim 无法拉取导致 docker-push 构建镜像失败。换用仍维护的 Temurin（Ubuntu 系，字体安装不变）。

Made with [Cursor](https://cursor.com)