### PR TITLE
release: 修复 Docker 基础镜像，重跑发布部署

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # 运行阶段
-FROM openjdk:17-jdk-slim
+# 注：openjdk 官方镜像已废弃下架（openjdk:17-jdk-slim 不再可拉取），
+# 改用仍维护的 Eclipse Temurin（同为 Ubuntu/Debian 系，apt-get 与字体包可用）。
+FROM eclipse-temurin:17-jdk-jammy
 
 # 安装字体和必要的依赖
 RUN apt-get update && \


### PR DESCRIPTION
承接 #117：main 的 docker-push 因 openjdk:17-jdk-slim 下架而构建失败。本次合入 Dockerfile 基础镜像修复（eclipse-temurin:17-jdk-jammy），触发 docker-push 完成构建推镜像与双机部署。

Made with [Cursor](https://cursor.com)