### PR TITLE
release: 修复登录 500（UserMapper 对齐）

### DIFF
--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -8,15 +8,13 @@
         <result property="username" column="username"/>
         <result property="password" column="password"/>
         <result property="email" column="email"/>
-        <result property="role" column="role"/>
         <result property="name" column="name"/>
         <result property="phone" column="phone"/>
         <result property="major" column="major"/>
         <result property="github" column="github"/>
-        <result property="dept" column="dept"/>
+        <result property="deptId" column="dept_id"/>
         <result property="avatar" column="avatar"/>
         <result property="status" column="status"/>
-        <result property="isMember" column="is_member"/>
         <result property="createTime" column="create_time"/>
         <result property="updateTime" column="update_time"/>
         <result property="isDeleted" column="is_deleted"/>
@@ -53,15 +51,13 @@
             <if test="username != null">username = #{username},</if>
             <if test="password != null">password = #{password},</if>
             <if test="email != null">email = #{email},</if>
-            <if test="role != null">role = #{role},</if>
             <if test="name != null">name = #{name},</if>
             <if test="phone != null">phone = #{phone},</if>
             <if test="major != null">major = #{major},</if>
             <if test="github != null">github = #{github},</if>
-            <if test="dept != null">dept = #{dept},</if>
+            <if test="deptId != null">dept_id = #{deptId},</if>
             <if test="avatar != null">avatar = #{avatar},</if>
             <if test="status != null">status = #{status},</if>
-            <if test="isMember != null">is_member = #{isMember},</if>
             update_time = NOW()
         </set>
         WHERE user_id = #{userId}


### PR DESCRIPTION
把登录修复合入 main 并部署：UserMapper 与重构后实体对齐，恢复邮箱/用户名/手机号登录。合并触发 docker-push 构建+双机部署。飞书密钥已在两节点 .env/compose 就位，本次部署一并生效。

Made with [Cursor](https://cursor.com)