### PR TITLE
ci(deploy): 部署步骤 command_timeout 提升至 30m

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -148,6 +148,7 @@ jobs:
           host: ${{ secrets.DEPLOY_HOST_B }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
+          command_timeout: 30m
           script: |
             set -e
             cd ~/boyuan-official
@@ -168,6 +169,7 @@ jobs:
           host: ${{ secrets.DEPLOY_HOST_A }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
+          command_timeout: 30m
           script: |
             set -e
             cd ~/boyuan-official
@@ -188,6 +190,7 @@ jobs:
           host: ${{ secrets.DEPLOY_HOST_A }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
+          command_timeout: 30m
           script: |
             code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/api/user/login || true)
             echo "LB /api 返回码: $code (401/400 表示反代通)"


### PR DESCRIPTION
修复流水线部署超时：约 1.3GB 镜像在 Node B 公网拉取超过 appleboy 默认 10m 命令超时，导致 pull 中断、健康检查失败。提升三处部署步骤 command_timeout 至 30m。建议后续改用 jre 基础镜像缩小体积。

Made with [Cursor](https://cursor.com)