### PR TITLE
perf(docker): 瘦身运行镜像 + 部署拉取重试，修复从节点部署超时

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -152,7 +152,13 @@ jobs:
           script: |
             set -e
             cd ~/boyuan-official
-            docker compose pull official
+            # 拉取镜像：公网从 Docker Hub 拉取偶发中断，重试至多 5 次
+            n=0
+            until docker compose pull official; do
+              n=$((n+1))
+              if [ "$n" -ge 5 ]; then echo "Node B 镜像拉取重试 5 次仍失败" >&2; exit 1; fi
+              echo "拉取失败，第 $n 次重试..."; sleep 10
+            done
             docker compose up -d official
             echo "等待 B 健康检查..."
             for i in $(seq 1 20); do
@@ -173,7 +179,13 @@ jobs:
           script: |
             set -e
             cd ~/boyuan-official
-            docker compose pull official
+            # 拉取镜像：公网从 Docker Hub 拉取偶发中断，重试至多 5 次
+            n=0
+            until docker compose pull official; do
+              n=$((n+1))
+              if [ "$n" -ge 5 ]; then echo "Node A 镜像拉取重试 5 次仍失败" >&2; exit 1; fi
+              echo "拉取失败，第 $n 次重试..."; sleep 10
+            done
             docker compose up -d official
             echo "等待 A 健康检查..."
             for i in $(seq 1 20); do

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,23 @@
 # 运行阶段
-# 注：openjdk 官方镜像已废弃下架（openjdk:17-jdk-slim 不再可拉取），
-# 改用仍维护的 Eclipse Temurin（同为 Ubuntu/Debian 系，apt-get 与字体包可用）。
-FROM eclipse-temurin:17-jdk-jammy
+# 注：openjdk 官方镜像已废弃下架，改用仍维护的 Eclipse Temurin。
+# 用 JRE（而非 JDK）基础镜像：应用是可执行 fat-jar，运行期无需编译器/JDK 工具，
+# 可显著缩小镜像体积、加快从节点(Node B)拉取，避免部署拉取超时。
+FROM eclipse-temurin:17-jre-jammy
 
-# 安装字体和必要的依赖
+# 仅安装 PDF 中文渲染所需的最小字体集：
+#   - fontconfig / libfontconfig1：字体配置库
+#   - fonts-noto-cjk：思源黑体，覆盖常用中日韩汉字（简历导出中文所需）
+#   - fonts-dejavu-core：覆盖拉丁字符
+# 刻意不装 fonts-noto-cjk-extra（数百 MB，仅含罕用扩展字，简历用不到）、
+# fonts-noto、dejavu-extra 等大体积包，以大幅缩小镜像。
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get install -y --no-install-recommends \
         fontconfig \
-        fonts-dejavu \
-        fonts-dejavu-core \
-        fonts-dejavu-extra \
-        fonts-noto \
-        fonts-noto-cjk \
-        fonts-noto-cjk-extra \
-        fonts-liberation \
         libfontconfig1 \
+        fonts-noto-cjk \
+        fonts-dejavu-core \
         && rm -rf /var/lib/apt/lists/* \
-        && fc-cache -fv
+        && fc-cache -f
 
 # 设置中文环境变量
 ENV LANG=zh_CN.UTF-8 \
@@ -33,7 +34,6 @@ COPY target/Official-*.jar official.jar
 EXPOSE 8080
 
 # 添加JVM参数以支持UTF-8编码和字体处理
-# 添加额外的字体配置和AWT设置
 ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -Djava.awt.headless=true -Djava.awt.fontconfig=/etc/fonts/fonts.conf -Dsun.java2d.fontpath=/usr/share/fonts"
 
 # 启动应用


### PR DESCRIPTION
## 背景
CI/CD 部署到 Node B 时 `docker compose pull` 拉取大镜像（488MB+70MB 新层）超过默认超时，`Run Command Timeout` 失败。

## 变更
- **Dockerfile 瘦身**：基础镜像 `eclipse-temurin:17-jdk-jammy` → `17-jre-jammy`；字体仅保留 `fonts-noto-cjk`（中文）+ `fonts-dejavu-core`（拉丁），移除 `fonts-noto-cjk-extra` 等数百 MB 无用包。镜像 ~1.3GB → 约 ~400-500MB，从节点拉取时间大幅下降。
- **部署拉取重试**：`docker-push.yml` 双节点 `docker compose pull` 增加至多 5 次重试，抵御公网从 Docker Hub 拉取的偶发中断。
- 配合 develop 上已有的 `command_timeout: 30m`，从节点部署稳定。

## 验证
- 简历 PDF 中文导出依赖 `fonts-noto-cjk` 已保留，常用汉字渲染不受影响。

Made with [Cursor](https://cursor.com)