### PR TITLE
feat(cors): 放行 admin.boyuan.club 管理端域名与腾讯云集群 IP

### DIFF
--- a/src/main/java/club/boyuan/official/infra/config/SecurityConfig.java
+++ b/src/main/java/club/boyuan/official/infra/config/SecurityConfig.java
@@ -124,12 +124,14 @@ public class SecurityConfig {
         // 允许的来源(origin)。注意：即使前端走同源 /api（nginx 反代），
         // 浏览器对 POST 等仍会带 Origin 头，Spring 会校验，故部署站点 origin 必须在此白名单内。
         // 生产站点入口
+        configuration.addAllowedOriginPattern("http://124.221.222.206");
+        configuration.addAllowedOriginPattern("https://124.221.222.206");
+        // 旧阿里云集群（回滚保险，观察期后可移除）
         configuration.addAllowedOriginPattern("http://8.159.153.140");
         configuration.addAllowedOriginPattern("https://8.159.153.140");
-        configuration.addAllowedOriginPattern("http://8.159.150.156");
-        configuration.addAllowedOriginPattern("https://8.159.150.156");
         configuration.addAllowedOriginPattern("http://official.boyuan.club");
         configuration.addAllowedOriginPattern("https://official.boyuan.club");
+        configuration.addAllowedOriginPattern("https://admin.boyuan.club");
         // 本地开发 / 直连
         configuration.addAllowedOriginPattern("http://localhost:3000");
         configuration.addAllowedOriginPattern("https://localhost:3000");


### PR DESCRIPTION
管理端界面拆分（admin.boyuan.club）的后端配套：CORS 白名单新增管理端域名与腾讯云 Node A IP，移除已下线的阿里云 B 节点 IP，保留 A 节点 IP 作回滚保险。

🤖 Generated with [Claude Code](https://claude.com/claude-code)