### PR TITLE
feat(student): 学生自助三件套——结果查询/简历PDF导出/面试改期申请

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6761,6 +6761,193 @@ paths:
               schema:
                 $ref: '#/components/schemas/ResponseMessageVoid'
           headers: {}
+  /api/interview/schedule/my-result:
+    get:
+      summary: 学生查询本人面试结果（录取/未录取）
+      deprecated: false
+      description: 按招募周期查询当前登录用户的面试结果。结果未录入（decision 为空）或未投递/未面试时 data 为 null。
+      tags:
+      - 面试预约（学生）
+      parameters:
+      - name: cycleId
+        in: query
+        description: 招募周期ID
+        required: true
+        example: 2
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    description: 业务状态码（200 表示成功）
+                  message:
+                    type: string
+                    description: 提示信息
+                  data:
+                    type: object
+                    nullable: true
+                    description: 面试结果；未出结果时为 null
+                    properties:
+                      resultId:
+                        type: integer
+                        description: 结果ID
+                      decision:
+                        type: integer
+                        description: 1=通过 2=未通过
+                      decisionAt:
+                        type: string
+                        nullable: true
+                        description: 决定时间
+                      assignedDeptId:
+                        type: integer
+                        nullable: true
+                        description: 录取部门ID
+                      assignedDeptName:
+                        type: string
+                        nullable: true
+                        description: 录取部门名称
+                required:
+                - code
+                - message
+          headers: {}
+  /api/interview/reschedule:
+    post:
+      summary: 学生提交面试改期申请
+      deprecated: false
+      description: 需本周期已分配面试；同一排期存在待处理申请时不可重复提交。管理员同意后在「分配与调剂」中人工重排。
+      tags:
+      - 面试预约（学生）
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - cycleId
+              - reason
+              properties:
+                cycleId:
+                  type: integer
+                  description: 招募周期ID
+                  example: 2
+                reason:
+                  type: string
+                  description: 改期原因（≤500字）
+                preferredTimeSlotIds:
+                  type: string
+                  nullable: true
+                  description: 期望时间窗ID列表（逗号分隔，可空）
+        required: true
+      responses:
+        '200':
+          description: 提交成功，返回申请记录
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RescheduleRequestEnvelope'
+          headers: {}
+  /api/interview/reschedule/my:
+    get:
+      summary: 学生查询本人最新改期申请
+      deprecated: false
+      description: 按招募周期查询本人最新一条改期申请；没有时 data 为 null。
+      tags:
+      - 面试预约（学生）
+      parameters:
+      - name: cycleId
+        in: query
+        required: true
+        example: 2
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RescheduleRequestEnvelope'
+          headers: {}
+  /api/interview/reschedule/admin/list:
+    get:
+      summary: 管理员查询改期申请列表
+      deprecated: false
+      description: 按周期查询改期申请，可按状态过滤（0待处理 1已同意 2已拒绝）。需 resume:audit 权限。
+      tags:
+      - 面试分配模块
+      parameters:
+      - name: cycleId
+        in: query
+        required: true
+        example: 2
+        schema:
+          type: integer
+      - name: status
+        in: query
+        required: false
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                  message:
+                    type: string
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/RescheduleRequest'
+          headers: {}
+  /api/interview/reschedule/admin/{requestId}/handle:
+    put:
+      summary: 管理员处理改期申请
+      deprecated: false
+      description: status=1 同意（随后在「分配与调剂」人工重排）；status=2 拒绝。可附 adminNote 备注。需 resume:audit 权限。
+      tags:
+      - 面试分配模块
+      parameters:
+      - name: requestId
+        in: path
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - status
+              properties:
+                status:
+                  type: integer
+                  description: 1=同意 2=拒绝
+                adminNote:
+                  type: string
+                  nullable: true
+                  description: 处理备注
+        required: true
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RescheduleRequestEnvelope'
+          headers: {}
   /api/interview/schedule/my:
     get:
       summary: 学生查询本人面试安排（方案B分配结果）
@@ -8295,6 +8482,57 @@ paths:
       security: []
 components:
   schemas:
+    RescheduleRequest:
+      type: object
+      description: 面试改期申请
+      properties:
+        requestId:
+          type: integer
+        scheduleId:
+          type: integer
+        resumeId:
+          type: integer
+        userId:
+          type: integer
+        cycleId:
+          type: integer
+        reason:
+          type: string
+        preferredTimeSlotIds:
+          type: string
+          nullable: true
+          description: 期望时间窗ID列表（逗号分隔）
+        status:
+          type: integer
+          description: 0待处理 1已同意 2已拒绝
+        adminNote:
+          type: string
+          nullable: true
+        handledBy:
+          type: integer
+          nullable: true
+        handledAt:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          nullable: true
+    RescheduleRequestEnvelope:
+      type: object
+      properties:
+        code:
+          type: integer
+          description: 业务状态码（200 表示成功）
+        message:
+          type: string
+          description: 提示信息
+        data:
+          nullable: true
+          allOf:
+          - $ref: '#/components/schemas/RescheduleRequest'
+      required:
+      - code
+      - message
     ResumeFieldDefinition:
       type: object
       description: 简历字段定义，与实体 `ResumeFieldDefinition` 一致

--- a/src/main/java/club/boyuan/official/domain/interview/controller/InterviewRescheduleController.java
+++ b/src/main/java/club/boyuan/official/domain/interview/controller/InterviewRescheduleController.java
@@ -1,0 +1,160 @@
+package club.boyuan.official.domain.interview.controller;
+
+import club.boyuan.official.common.dto.ResponseMessage;
+import club.boyuan.official.common.utils.SecurityUtil;
+import club.boyuan.official.domain.resume.service.IResumeService;
+import club.boyuan.official.domain.user.service.IUserService;
+import club.boyuan.official.persistence.entity.InterviewRescheduleRequest;
+import club.boyuan.official.persistence.entity.InterviewSchedule;
+import club.boyuan.official.persistence.entity.Resume;
+import club.boyuan.official.persistence.entity.User;
+import club.boyuan.official.persistence.mapper.InterviewRescheduleRequestMapper;
+import club.boyuan.official.persistence.mapper.InterviewScheduleMapper;
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 面试改期申请：
+ * 学生对已分配的面试提出改期（附原因与期望时间窗），
+ * 管理员审核（同意后在「分配与调剂」中人工重排，或拒绝并备注）。
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/interview/reschedule")
+@AllArgsConstructor
+public class InterviewRescheduleController {
+
+    private final IUserService userService;
+
+    private final IResumeService resumeService;
+
+    private final InterviewRescheduleRequestMapper rescheduleMapper;
+
+    private final InterviewScheduleMapper interviewScheduleMapper;
+
+    /**
+     * 学生提交改期申请。要求本周期已有面试排期；同一排期存在待处理申请时不可重复提交。
+     */
+    @PostMapping
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ResponseMessage<InterviewRescheduleRequest>> submit(
+            @RequestBody Map<String, Object> body) {
+        Integer cycleId = body.get("cycleId") == null ? null : Integer.valueOf(String.valueOf(body.get("cycleId")));
+        String reason = body.get("reason") == null ? null : String.valueOf(body.get("reason")).trim();
+        String preferredSlots = body.get("preferredTimeSlotIds") == null
+                ? null : String.valueOf(body.get("preferredTimeSlotIds"));
+        if (cycleId == null || reason == null || reason.isEmpty()) {
+            return ResponseEntity.badRequest().body(ResponseMessage.error(400, "cycleId 与 reason 不能为空"));
+        }
+        if (reason.length() > 500) {
+            return ResponseEntity.badRequest().body(ResponseMessage.error(400, "原因不能超过 500 字"));
+        }
+
+        User currentUser = userService.getUserByUsername(SecurityUtil.getCurrentUsername());
+        Resume resume = resumeService.getResumeByUserIdAndCycleId(currentUser.getUserId(), cycleId);
+        if (resume == null) {
+            return ResponseEntity.badRequest().body(ResponseMessage.error(400, "本周期尚未投递简历"));
+        }
+        InterviewSchedule schedule = interviewScheduleMapper.selectOne(
+                new LambdaQueryWrapper<InterviewSchedule>()
+                        .eq(InterviewSchedule::getResumeId, resume.getResumeId())
+                        .eq(InterviewSchedule::getCycleId, cycleId)
+                        .orderByDesc(InterviewSchedule::getScheduleId)
+                        .last("LIMIT 1"));
+        if (schedule == null) {
+            return ResponseEntity.badRequest().body(ResponseMessage.error(400, "尚未分配面试，无需改期"));
+        }
+        Long pending = rescheduleMapper.selectCount(new LambdaQueryWrapper<InterviewRescheduleRequest>()
+                .eq(InterviewRescheduleRequest::getScheduleId, schedule.getScheduleId())
+                .eq(InterviewRescheduleRequest::getStatus, InterviewRescheduleRequest.STATUS_PENDING));
+        if (pending != null && pending > 0) {
+            return ResponseEntity.badRequest().body(ResponseMessage.error(400, "已有待处理的改期申请，请耐心等待"));
+        }
+
+        InterviewRescheduleRequest req = new InterviewRescheduleRequest()
+                .setScheduleId(schedule.getScheduleId())
+                .setResumeId(resume.getResumeId())
+                .setUserId(currentUser.getUserId())
+                .setCycleId(cycleId)
+                .setReason(reason)
+                .setPreferredTimeSlotIds(preferredSlots)
+                .setStatus(InterviewRescheduleRequest.STATUS_PENDING);
+        rescheduleMapper.insert(req);
+        log.info("用户{}提交改期申请，scheduleId={}, requestId={}",
+                currentUser.getUsername(), schedule.getScheduleId(), req.getRequestId());
+        return ResponseEntity.ok(ResponseMessage.success(req));
+    }
+
+    /**
+     * 学生查询本人在指定周期的最新改期申请；没有时 data 为 null。
+     */
+    @GetMapping("/my")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ResponseMessage<InterviewRescheduleRequest>> my(@RequestParam Integer cycleId) {
+        User currentUser = userService.getUserByUsername(SecurityUtil.getCurrentUsername());
+        InterviewRescheduleRequest req = rescheduleMapper.selectOne(
+                new LambdaQueryWrapper<InterviewRescheduleRequest>()
+                        .eq(InterviewRescheduleRequest::getUserId, currentUser.getUserId())
+                        .eq(InterviewRescheduleRequest::getCycleId, cycleId)
+                        .orderByDesc(InterviewRescheduleRequest::getRequestId)
+                        .last("LIMIT 1"));
+        return ResponseEntity.ok(ResponseMessage.success(req));
+    }
+
+    /**
+     * 管理员按周期查询改期申请列表（可按状态过滤，默认全部）。
+     */
+    @GetMapping("/admin/list")
+    @PreAuthorize("hasAuthority('resume:audit')")
+    public ResponseEntity<ResponseMessage<List<InterviewRescheduleRequest>>> adminList(
+            @RequestParam Integer cycleId,
+            @RequestParam(required = false) Integer status) {
+        LambdaQueryWrapper<InterviewRescheduleRequest> qw = new LambdaQueryWrapper<InterviewRescheduleRequest>()
+                .eq(InterviewRescheduleRequest::getCycleId, cycleId)
+                .orderByAsc(InterviewRescheduleRequest::getStatus)
+                .orderByDesc(InterviewRescheduleRequest::getRequestId);
+        if (status != null) {
+            qw.eq(InterviewRescheduleRequest::getStatus, status);
+        }
+        return ResponseEntity.ok(ResponseMessage.success(rescheduleMapper.selectList(qw)));
+    }
+
+    /**
+     * 管理员处理改期申请：status=1 同意（随后在「分配与调剂」人工重排）；status=2 拒绝。
+     */
+    @PutMapping("/admin/{requestId}/handle")
+    @PreAuthorize("hasAuthority('resume:audit')")
+    public ResponseEntity<ResponseMessage<InterviewRescheduleRequest>> handle(
+            @PathVariable Integer requestId,
+            @RequestBody Map<String, Object> body) {
+        Integer status = body.get("status") == null ? null : Integer.valueOf(String.valueOf(body.get("status")));
+        String adminNote = body.get("adminNote") == null ? null : String.valueOf(body.get("adminNote"));
+        if (status == null || (status != InterviewRescheduleRequest.STATUS_APPROVED
+                && status != InterviewRescheduleRequest.STATUS_REJECTED)) {
+            return ResponseEntity.badRequest().body(ResponseMessage.error(400, "status 仅支持 1(同意)/2(拒绝)"));
+        }
+        InterviewRescheduleRequest req = rescheduleMapper.selectById(requestId);
+        if (req == null) {
+            return ResponseEntity.badRequest().body(ResponseMessage.error(400, "申请不存在"));
+        }
+        if (req.getStatus() != null && req.getStatus() != InterviewRescheduleRequest.STATUS_PENDING) {
+            return ResponseEntity.badRequest().body(ResponseMessage.error(400, "该申请已处理"));
+        }
+        User handler = userService.getUserByUsername(SecurityUtil.getCurrentUsername());
+        req.setStatus(status)
+                .setAdminNote(adminNote)
+                .setHandledBy(handler.getUserId())
+                .setHandledAt(LocalDateTime.now());
+        rescheduleMapper.updateById(req);
+        log.info("管理员{}处理改期申请{}，status={}", handler.getUsername(), requestId, status);
+        return ResponseEntity.ok(ResponseMessage.success(req));
+    }
+}

--- a/src/main/java/club/boyuan/official/domain/interview/controller/InterviewScheduleController.java
+++ b/src/main/java/club/boyuan/official/domain/interview/controller/InterviewScheduleController.java
@@ -51,6 +51,50 @@ public class InterviewScheduleController {
 
     private final DepartmentMapper departmentMapper;
 
+    private final club.boyuan.official.persistence.mapper.InterviewResultMapper interviewResultMapper;
+
+    /**
+     * 学生查询本人在指定周期的面试结果（录取/未录取）。
+     * 结果未出（或管理员尚未录入 decision）时 data 为 null。
+     */
+    @GetMapping("/my-result")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ResponseMessage<Map<String, Object>>> getMyResult(@RequestParam Integer cycleId) {
+        User currentUser = userService.getUserByUsername(SecurityUtil.getCurrentUsername());
+        Resume resume = resumeService.getResumeByUserIdAndCycleId(currentUser.getUserId(), cycleId);
+        if (resume == null) {
+            return ResponseEntity.ok(ResponseMessage.success(null));
+        }
+        InterviewSchedule schedule = interviewScheduleMapper.selectOne(
+                new LambdaQueryWrapper<InterviewSchedule>()
+                        .eq(InterviewSchedule::getResumeId, resume.getResumeId())
+                        .eq(InterviewSchedule::getCycleId, cycleId)
+                        .orderByDesc(InterviewSchedule::getScheduleId)
+                        .last("LIMIT 1"));
+        if (schedule == null) {
+            return ResponseEntity.ok(ResponseMessage.success(null));
+        }
+        club.boyuan.official.persistence.entity.InterviewResult result = interviewResultMapper.selectOne(
+                new LambdaQueryWrapper<club.boyuan.official.persistence.entity.InterviewResult>()
+                        .eq(club.boyuan.official.persistence.entity.InterviewResult::getScheduleId, schedule.getScheduleId())
+                        .eq(club.boyuan.official.persistence.entity.InterviewResult::getUserId, currentUser.getUserId())
+                        .orderByDesc(club.boyuan.official.persistence.entity.InterviewResult::getResultId)
+                        .last("LIMIT 1"));
+        if (result == null || result.getDecision() == null) {
+            return ResponseEntity.ok(ResponseMessage.success(null));
+        }
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("resultId", result.getResultId());
+        data.put("decision", result.getDecision()); // 1=通过 2=未通过
+        data.put("decisionAt", result.getDecisionAt());
+        if (result.getAssignedDeptId() != null) {
+            Department dept = departmentMapper.selectById(result.getAssignedDeptId());
+            data.put("assignedDeptId", result.getAssignedDeptId());
+            data.put("assignedDeptName", dept != null ? dept.getDeptName() : null);
+        }
+        return ResponseEntity.ok(ResponseMessage.success(data));
+    }
+
     /**
      * 学生查询本人在指定周期的面试安排（方案B分配结果）。
      * 未分配时 data 为 null；已分配时返回时间/部门/地点等信息。

--- a/src/main/java/club/boyuan/official/domain/resume/controller/ResumeController.java
+++ b/src/main/java/club/boyuan/official/domain/resume/controller/ResumeController.java
@@ -295,7 +295,7 @@ public class ResumeController {
      * 因直接向响应流写二进制，保留局部异常处理（无法交给 GlobalExceptionHandler 处理半写响应）。
      */
     @GetMapping("/export/pdf/{resumeId}")
-    @PreAuthorize("hasAuthority('resume:view')")
+    @PreAuthorize("isAuthenticated()")  // 归属校验在方法内：本人或具备管理权限者可导出
     public void exportResumeToPdf(@PathVariable Integer resumeId, HttpServletResponse response) {
         try {
             User currentUser = currentUser();

--- a/src/main/java/club/boyuan/official/persistence/entity/InterviewRescheduleRequest.java
+++ b/src/main/java/club/boyuan/official/persistence/entity/InterviewRescheduleRequest.java
@@ -1,0 +1,73 @@
+package club.boyuan.official.persistence.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+/**
+ * <p>
+ * 面试改期申请
+ * </p>
+ */
+@Data
+@EqualsAndHashCode(callSuper = false)
+@Accessors(chain = true)
+@TableName("interview_reschedule_request")
+public class InterviewRescheduleRequest implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** 状态：待处理 */
+    public static final int STATUS_PENDING = 0;
+    /** 状态：已同意（由管理员在「分配与调剂」中重排） */
+    public static final int STATUS_APPROVED = 1;
+    /** 状态：已拒绝 */
+    public static final int STATUS_REJECTED = 2;
+
+    @TableId(value = "request_id", type = IdType.AUTO)
+    private Integer requestId;
+
+    @TableField("schedule_id")
+    private Integer scheduleId;
+
+    @TableField("resume_id")
+    private Integer resumeId;
+
+    @TableField("user_id")
+    private Integer userId;
+
+    @TableField("cycle_id")
+    private Integer cycleId;
+
+    @TableField("reason")
+    private String reason;
+
+    /** 期望时间窗ID列表（逗号分隔，可空） */
+    @TableField("preferred_time_slot_ids")
+    private String preferredTimeSlotIds;
+
+    @TableField("status")
+    private Integer status;
+
+    @TableField("admin_note")
+    private String adminNote;
+
+    @TableField("handled_by")
+    private Integer handledBy;
+
+    @TableField("handled_at")
+    private LocalDateTime handledAt;
+
+    @TableField("created_at")
+    private LocalDateTime createdAt;
+
+    @TableField("updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/club/boyuan/official/persistence/mapper/InterviewRescheduleRequestMapper.java
+++ b/src/main/java/club/boyuan/official/persistence/mapper/InterviewRescheduleRequestMapper.java
@@ -1,0 +1,10 @@
+package club.boyuan.official.persistence.mapper;
+
+import club.boyuan.official.persistence.entity.InterviewRescheduleRequest;
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+
+/**
+ * 面试改期申请 Mapper
+ */
+public interface InterviewRescheduleRequestMapper extends BaseMapper<InterviewRescheduleRequest> {
+}

--- a/src/main/resources/db/migration/V8__interview_reschedule_request.sql
+++ b/src/main/resources/db/migration/V8__interview_reschedule_request.sql
@@ -1,0 +1,19 @@
+-- 面试改期申请：学生对已分配的面试时间提出改期，管理员审核后用「人工调剂」重排
+CREATE TABLE IF NOT EXISTS interview_reschedule_request (
+    request_id INT AUTO_INCREMENT PRIMARY KEY COMMENT '申请ID',
+    schedule_id INT NOT NULL COMMENT '关联面试排期ID',
+    resume_id INT NOT NULL COMMENT '关联简历ID',
+    user_id INT NOT NULL COMMENT '申请人用户ID',
+    cycle_id INT NOT NULL COMMENT '招募周期ID',
+    reason VARCHAR(500) NOT NULL COMMENT '改期原因',
+    preferred_time_slot_ids VARCHAR(200) NULL COMMENT '期望时间窗ID列表（逗号分隔，可空）',
+    status TINYINT NOT NULL DEFAULT 0 COMMENT '0待处理 1已同意 2已拒绝',
+    admin_note VARCHAR(500) NULL COMMENT '管理员处理备注',
+    handled_by INT NULL COMMENT '处理人用户ID',
+    handled_at DATETIME NULL COMMENT '处理时间',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    KEY idx_cycle_status (cycle_id, status),
+    KEY idx_user (user_id),
+    KEY idx_schedule (schedule_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci COMMENT = '面试改期申请';


### PR DESCRIPTION
配套前端「申请中心」页使用：

- **结果查询** `GET /api/interview/schedule/my-result`（decision 未录入不泄露）
- **PDF 导出放开本人**（方法内归属校验早已存在，仅调整入口注解）
- **改期申请**全套（V8 迁移 + 学生提交/查询 + 管理员列表/处理）
- openapi.yaml 已同步并通过 spec 校验

🤖 Generated with [Claude Code](https://claude.com/claude-code)