### PR TITLE
fix(resume): 简历查询支持只读模式，登录不再误建草稿

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3108,7 +3108,7 @@ paths:
     get:
       summary: 获取/创建简历
       deprecated: false
-      description: 获取当前用户在指定招募周期的简历；若不存在则自动创建草稿。
+      description: 获取当前用户在指定招募周期的简历；若不存在且 autoCreate=true（默认）则自动创建草稿。autoCreate=false 时为只读查询（用于首页进度卡等场景），不存在时 data 为 null。
       tags:
       - 简历相关功能——普通用户
       parameters:
@@ -3118,6 +3118,14 @@ paths:
         required: true
         schema:
           type: integer
+      - name: autoCreate
+        in: query
+        description: 不存在时是否自动创建草稿（默认 true）
+        required: false
+        example: false
+        schema:
+          type: boolean
+          default: true
       responses:
         '200':
           description: ''

--- a/src/main/java/club/boyuan/official/domain/resume/controller/ResumeController.java
+++ b/src/main/java/club/boyuan/official/domain/resume/controller/ResumeController.java
@@ -110,11 +110,17 @@ public class ResumeController {
      */
     @GetMapping("/cycle/{cycleId}")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<ResponseMessage<?>> getResumeByCycleId(@PathVariable Integer cycleId) {
+    public ResponseEntity<ResponseMessage<?>> getResumeByCycleId(
+            @PathVariable Integer cycleId,
+            @RequestParam(required = false, defaultValue = "true") Boolean autoCreate) {
         User currentUser = currentUser();
         logger.info("用户{}({})获取招募周期ID为{}的简历", currentUser.getUsername(), currentUser.getUserId(), cycleId);
 
         ResumeDTO resumeDTO = resumeService.getResumeWithFieldValues(currentUser.getUserId(), cycleId);
+        // 只读查询（如首页进度卡）：不存在时不自动创建草稿，直接返回 null
+        if (resumeDTO == null && !Boolean.TRUE.equals(autoCreate)) {
+            return ResponseEntity.ok(ResponseMessage.success(null));
+        }
         if (resumeDTO == null) {
             Resume resume = new Resume();
             resume.setUserId(currentUser.getUserId());


### PR DESCRIPTION
GET /api/resumes/cycle/{cycleId} 增加 autoCreate 开关（默认 true 兼容既有表单流程）；false 时只读查询。配套前端首页/申请进度页改用只读查询。

🤖 Generated with [Claude Code](https://claude.com/claude-code)