### PR TITLE
feat(resume): 查询本人历届申请接口

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3104,6 +3104,52 @@ paths:
                 - message
                 - data
           headers: {}
+  /api/resumes/my:
+    get:
+      summary: 查询本人历届申请（各周期简历概要）
+      deprecated: false
+      description: 返回当前登录用户在所有招募周期的简历概要（按周期倒序），供个人主页「我的申请」列表使用。
+      tags:
+      - 简历相关功能——普通用户
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    description: 业务状态码（200 表示成功）
+                  message:
+                    type: string
+                    description: 提示信息
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        resumeId:
+                          type: integer
+                        cycleId:
+                          type: integer
+                        cycleName:
+                          type: string
+                          nullable: true
+                        academicYear:
+                          type: string
+                          nullable: true
+                        status:
+                          type: integer
+                          description: 1草稿 2已提交 3评审中 4通过 5未通过
+                        createdAt:
+                          type: string
+                          nullable: true
+                required:
+                - code
+                - message
+          headers: {}
   /api/resumes/cycle/{cycleId}:
     get:
       summary: 获取/创建简历

--- a/src/main/java/club/boyuan/official/domain/resume/controller/ResumeController.java
+++ b/src/main/java/club/boyuan/official/domain/resume/controller/ResumeController.java
@@ -44,6 +44,38 @@ public class ResumeController {
     private final IResumeService resumeService;
     private final IResumeFieldDefinitionService fieldDefinitionService;
     private final IUserService userService;
+    private final club.boyuan.official.persistence.mapper.ResumeMapper resumeMapper;
+    private final club.boyuan.official.persistence.mapper.RecruitmentCycleMapper recruitmentCycleMapper;
+
+    /**
+     * 查询本人历届申请（各周期的简历概要，按周期倒序）。
+     * 供个人主页「我的申请」列表使用；点击后按 cycleId 查看该届完整进度。
+     */
+    @GetMapping("/my")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ResponseMessage<?>> getMyResumes() {
+        User currentUser = currentUser();
+        java.util.List<Resume> resumes = resumeMapper.selectList(
+                new com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper<Resume>()
+                        .eq(Resume::getUserId, currentUser.getUserId())
+                        .orderByDesc(Resume::getCycleId));
+        java.util.List<java.util.Map<String, Object>> list = new java.util.ArrayList<>();
+        for (Resume r : resumes) {
+            java.util.Map<String, Object> item = new java.util.LinkedHashMap<>();
+            item.put("resumeId", r.getResumeId());
+            item.put("cycleId", r.getCycleId());
+            item.put("status", r.getStatus());
+            item.put("createdAt", r.getCreatedAt());
+            if (r.getCycleId() != null) {
+                club.boyuan.official.persistence.entity.RecruitmentCycle cycle =
+                        recruitmentCycleMapper.selectById(r.getCycleId());
+                item.put("cycleName", cycle != null ? cycle.getCycleName() : null);
+                item.put("academicYear", cycle != null ? cycle.getAcademicYear() : null);
+            }
+            list.add(item);
+        }
+        return ResponseEntity.ok(ResponseMessage.success(list));
+    }
 
     /**
      * 获取指定招募周期的简历字段定义


### PR DESCRIPTION
GET /api/resumes/my —— 跨周期申请列表（个人主页入口用），数据按 cycleId 天然隔离。openapi 已同步并通过校验。

🤖 Generated with [Claude Code](https://claude.com/claude-code)