### PR TITLE
fix(mapper): 批量更新改为 CASE WHEN 单语句，修复多语句 SQL 报错

### DIFF
--- a/src/main/resources/mapper/RecruitmentCycleMapper.xml
+++ b/src/main/resources/mapper/RecruitmentCycleMapper.xml
@@ -51,20 +51,49 @@
         </foreach>
     </delete>
 
+    <!-- 批量更新：CASE WHEN 单语句实现（JDBC 默认禁止 foreach separator=";" 的多语句拼接） -->
     <update id="batchUpdate" parameterType="java.util.List">
-        <foreach collection="recruitmentCycles" item="item" separator=";">
-            UPDATE recruitment_cycle
-            <set>
-                <if test="item.cycleName != null">cycle_name = #{item.cycleName},</if>
-                <if test="item.description != null">description = #{item.description},</if>
-                <if test="item.startDate != null">start_date = #{item.startDate},</if>
-                <if test="item.endDate != null">end_date = #{item.endDate},</if>
-                <if test="item.academicYear != null">academic_year = #{item.academicYear},</if>
-                <if test="item.status != null">status = #{item.status},</if>
-                <if test="item.isActive != null">is_active = #{item.isActive},</if>
-                updated_at = NOW()
-            </set>
-            WHERE cycle_id = #{item.cycleId}
+        UPDATE recruitment_cycle
+        SET
+        cycle_name = CASE cycle_id
+        <foreach collection="recruitmentCycles" item="item">
+            <if test="item.cycleName != null">WHEN #{item.cycleId} THEN #{item.cycleName}</if>
+        </foreach>
+        ELSE cycle_name END,
+        description = CASE cycle_id
+        <foreach collection="recruitmentCycles" item="item">
+            <if test="item.description != null">WHEN #{item.cycleId} THEN #{item.description}</if>
+        </foreach>
+        ELSE description END,
+        start_date = CASE cycle_id
+        <foreach collection="recruitmentCycles" item="item">
+            <if test="item.startDate != null">WHEN #{item.cycleId} THEN #{item.startDate}</if>
+        </foreach>
+        ELSE start_date END,
+        end_date = CASE cycle_id
+        <foreach collection="recruitmentCycles" item="item">
+            <if test="item.endDate != null">WHEN #{item.cycleId} THEN #{item.endDate}</if>
+        </foreach>
+        ELSE end_date END,
+        academic_year = CASE cycle_id
+        <foreach collection="recruitmentCycles" item="item">
+            <if test="item.academicYear != null">WHEN #{item.cycleId} THEN #{item.academicYear}</if>
+        </foreach>
+        ELSE academic_year END,
+        status = CASE cycle_id
+        <foreach collection="recruitmentCycles" item="item">
+            <if test="item.status != null">WHEN #{item.cycleId} THEN #{item.status}</if>
+        </foreach>
+        ELSE status END,
+        is_active = CASE cycle_id
+        <foreach collection="recruitmentCycles" item="item">
+            <if test="item.isActive != null">WHEN #{item.cycleId} THEN #{item.isActive}</if>
+        </foreach>
+        ELSE is_active END,
+        updated_at = NOW()
+        WHERE cycle_id IN
+        <foreach collection="recruitmentCycles" item="item" open="(" separator="," close=")">
+            #{item.cycleId}
         </foreach>
     </update>
 

--- a/src/main/resources/mapper/ResumeFieldValueMapper.xml
+++ b/src/main/resources/mapper/ResumeFieldValueMapper.xml
@@ -39,14 +39,21 @@
         WHERE value_id = #{valueId}
     </update>
 
+    <!-- 批量更新：单条 CASE WHEN 语句实现。
+         注意不要用 foreach separator=";" 拼多条 UPDATE——JDBC 默认禁止多语句，
+         会抛 SQLSyntaxErrorException（历史上因该方法从未被触发而长期潜伏）。 -->
     <update id="batchUpdate" parameterType="java.util.List">
-        <foreach collection="fieldValues" item="item" separator=";">
-            UPDATE resume_field_value
-            <set>
-                <if test="item.fieldValue != null">field_value = #{item.fieldValue},</if>
-                updated_at = NOW()
-            </set>
-            WHERE value_id = #{item.valueId}
+        UPDATE resume_field_value
+        SET field_value = CASE value_id
+        <foreach collection="fieldValues" item="item">
+            <if test="item.fieldValue != null">WHEN #{item.valueId} THEN #{item.fieldValue}</if>
+        </foreach>
+            ELSE field_value
+        END,
+        updated_at = NOW()
+        WHERE value_id IN
+        <foreach collection="fieldValues" item="item" open="(" separator="," close=")">
+            #{item.valueId}
         </foreach>
     </update>
 


### PR DESCRIPTION
用户更新简历字段值时触发 `batchUpdate` 多语句拼接（foreach separator=';'）导致 SQLSyntaxErrorException。两个 mapper（简历字段值/招募周期）同款问题一并修复为 CASE WHEN 单语句。该代码路径因数据从未落库而长期未执行，属前端保存修复后暴露的存量 bug。

🤖 Generated with [Claude Code](https://claude.com/claude-code)