### PR TITLE
fix(interview): 排期插入补齐 user_id + 场次分配名单查询

### DIFF
--- a/src/main/java/club/boyuan/official/domain/interview/controller/SessionAssignmentController.java
+++ b/src/main/java/club/boyuan/official/domain/interview/controller/SessionAssignmentController.java
@@ -27,6 +27,50 @@ public class SessionAssignmentController {
 
     private final ISessionAssignmentService sessionAssignmentService;
     private final IInterviewSessionService interviewSessionService;
+    private final club.boyuan.official.persistence.mapper.InterviewScheduleMapper interviewScheduleMapper;
+    private final club.boyuan.official.persistence.mapper.UserMapper userMapper;
+    private final club.boyuan.official.persistence.mapper.DepartmentMapper departmentMapper;
+
+    /**
+     * 查询某周期的已分配名单（可按场次过滤），按面试时间排序。
+     * 供管理端「场次」查看每个场次/时间段实际分配到的候选人。
+     */
+    @GetMapping("/cycles/{cycleId}/schedules")
+    public ResponseEntity<ResponseMessage<java.util.List<java.util.Map<String, Object>>>> listSchedules(
+            @PathVariable Integer cycleId,
+            @RequestParam(required = false) Integer sessionId) {
+        com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper<club.boyuan.official.persistence.entity.InterviewSchedule> qw =
+                new com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper<club.boyuan.official.persistence.entity.InterviewSchedule>()
+                        .eq(club.boyuan.official.persistence.entity.InterviewSchedule::getCycleId, cycleId)
+                        .orderByAsc(club.boyuan.official.persistence.entity.InterviewSchedule::getInterviewTime);
+        if (sessionId != null) {
+            qw.eq(club.boyuan.official.persistence.entity.InterviewSchedule::getSessionId, sessionId);
+        }
+        java.util.List<club.boyuan.official.persistence.entity.InterviewSchedule> schedules =
+                interviewScheduleMapper.selectList(qw);
+        java.util.List<java.util.Map<String, Object>> result = new java.util.ArrayList<>();
+        for (club.boyuan.official.persistence.entity.InterviewSchedule sc : schedules) {
+            java.util.Map<String, Object> item = new java.util.LinkedHashMap<>();
+            item.put("scheduleId", sc.getScheduleId());
+            item.put("resumeId", sc.getResumeId());
+            item.put("userId", sc.getUserId());
+            item.put("sessionId", sc.getSessionId());
+            item.put("interviewTime", sc.getInterviewTime());
+            item.put("status", sc.getStatus());
+            item.put("notes", sc.getNotes());
+            if (sc.getUserId() != null) {
+                club.boyuan.official.persistence.entity.User u = userMapper.selectById(sc.getUserId());
+                item.put("name", u != null ? (u.getName() != null ? u.getName() : u.getUsername()) : null);
+                item.put("username", u != null ? u.getUsername() : null);
+            }
+            if (sc.getDeptId() != null) {
+                club.boyuan.official.persistence.entity.Department d = departmentMapper.selectById(sc.getDeptId());
+                item.put("deptName", d != null ? d.getDeptName() : null);
+            }
+            result.add(item);
+        }
+        return ResponseEntity.ok(ResponseMessage.success(result));
+    }
 
     /**
      * 为某周期一键分配面试场次（可重复执行，仅处理尚未分配的候选人）。

--- a/src/main/java/club/boyuan/official/domain/interview/service/impl/InterviewBookingAsyncPersistenceService.java
+++ b/src/main/java/club/boyuan/official/domain/interview/service/impl/InterviewBookingAsyncPersistenceService.java
@@ -64,6 +64,7 @@ public class InterviewBookingAsyncPersistenceService {
         } else {
             schedule = new InterviewSchedule()
                     .setResumeId(message.getResumeId())
+                    .setUserId(message.getUserId())
                     .setCycleId(message.getCycleId())
                     .setSlotId(message.getSlotId())
                     .setInterviewTime(fineInterviewTime)

--- a/src/main/java/club/boyuan/official/domain/interview/service/impl/InterviewBookingServiceImpl.java
+++ b/src/main/java/club/boyuan/official/domain/interview/service/impl/InterviewBookingServiceImpl.java
@@ -214,6 +214,7 @@ public class InterviewBookingServiceImpl implements IInterviewBookingService {
         }
         InterviewSchedule schedule = new InterviewSchedule()
                 .setResumeId(resume.getResumeId())
+                .setUserId(resume.getUserId())
                 .setCycleId(request.getCycleId())
                 .setSlotId(request.getSlotId())
                 .setInterviewTime(resolveFineInterviewTimeAfterOccupy(request.getSlotId()))

--- a/src/main/java/club/boyuan/official/domain/interview/service/impl/InterviewScheduleServiceImpl.java
+++ b/src/main/java/club/boyuan/official/domain/interview/service/impl/InterviewScheduleServiceImpl.java
@@ -304,6 +304,7 @@ public class InterviewScheduleServiceImpl extends ServiceImpl<InterviewScheduleM
 
                 InterviewSchedule schedule = new InterviewSchedule()
                         .setResumeId(resume.getResumeId())
+                        .setUserId(resume.getUserId())
                         .setCycleId(resume.getCycleId())
                         .setSlotId(slotId)
                         .setInterviewTime(interviewDateTime)
@@ -1029,6 +1030,7 @@ public class InterviewScheduleServiceImpl extends ServiceImpl<InterviewScheduleM
                         // 创建面试安排实体
                         InterviewSchedule schedule = new InterviewSchedule()
                                 .setResumeId(resume.getResumeId())
+                                .setUserId(resume.getUserId())
                                 .setCycleId(resume.getCycleId())
                                 .setSlotId(slotId)
                                 .setInterviewTime(assignedSlot)

--- a/src/main/java/club/boyuan/official/domain/interview/service/impl/SessionAssignmentServiceImpl.java
+++ b/src/main/java/club/boyuan/official/domain/interview/service/impl/SessionAssignmentServiceImpl.java
@@ -202,6 +202,7 @@ public class SessionAssignmentServiceImpl implements ISessionAssignmentService {
         if (isNew) {
             schedule = new InterviewSchedule()
                     .setResumeId(resumeId)
+                    .setUserId(resume.getUserId())
                     .setCycleId(target.getCycleId())
                     .setSyncStatus(0)
                     .setNotifStatus(0);
@@ -249,6 +250,7 @@ public class SessionAssignmentServiceImpl implements ISessionAssignmentService {
         LocalDateTime start = computeStart(state.timeSlot, index, durationOf(state.session));
         InterviewSchedule schedule = new InterviewSchedule()
                 .setResumeId(resume.getResumeId())
+                .setUserId(resume.getUserId())
                 .setCycleId(state.session.getCycleId())
                 .setSlotId(null)
                 .setSessionId(state.session.getSessionId())

--- a/src/main/java/club/boyuan/official/persistence/entity/InterviewSchedule.java
+++ b/src/main/java/club/boyuan/official/persistence/entity/InterviewSchedule.java
@@ -39,6 +39,12 @@ public class InterviewSchedule implements Serializable {
     private Integer resumeId;
 
     /**
+     * 用户ID（表列 NOT NULL；实体曾缺失该字段导致所有排期插入失败）
+     */
+    @TableField("user_id")
+    private Integer userId;
+
+    /**
      * 招募活动ID
      */
     @TableField("cycle_id")


### PR DESCRIPTION
**一键分配系统异常根因**：interview_schedule.user_id 列 NOT NULL 但实体缺字段，所有排期插入路径全部失败。补字段+5处创建点填充。另新增按场次查询分配名单接口供管理端展示。

🤖 Generated with [Claude Code](https://claude.com/claude-code)